### PR TITLE
feat: Add Papers With Code and Hugging Face datasets

### DIFF
--- a/firstdata/sources/sectors/J-information-communication/huggingface-datasets.json
+++ b/firstdata/sources/sectors/J-information-communication/huggingface-datasets.json
@@ -1,0 +1,66 @@
+{
+  "id": "huggingface-datasets",
+  "name": {
+    "en": "Hugging Face Datasets",
+    "zh": "Hugging Face 数据集"
+  },
+  "description": {
+    "en": "Hugging Face Datasets Hub is the largest open platform for sharing and accessing machine learning datasets. It hosts over 100,000 datasets covering NLP, computer vision, audio, and multimodal tasks. The platform provides standardized dataset cards with licensing, citation info, and usage examples. The accompanying 'datasets' Python library enables programmatic access with streaming, caching, and preprocessing capabilities.",
+    "zh": "Hugging Face 数据集中心是分享和访问机器学习数据集的最大开放平台。托管超过 100,000 个数据集，涵盖 NLP、计算机视觉、音频和多模态任务。平台提供标准化数据集卡片，包含许可证、引用信息和使用示例。配套的 'datasets' Python 库支持流式访问、缓存和预处理功能。"
+  },
+  "website": "https://huggingface.co",
+  "data_url": "https://huggingface.co/datasets",
+  "api_url": "https://huggingface.co/docs/datasets/",
+  "country": null,
+  "domains": [
+    "Machine Learning",
+    "Natural Language Processing",
+    "Computer Vision",
+    "Audio Processing",
+    "Multimodal AI",
+    "Deep Learning"
+  ],
+  "geographic_scope": "global",
+  "update_frequency": "daily",
+  "authority_level": "market",
+  "tags": [
+    "machine-learning",
+    "datasets",
+    "nlp",
+    "transformers",
+    "deep-learning",
+    "open-source",
+    "llm",
+    "large-language-models",
+    "computer-vision",
+    "audio",
+    "multimodal",
+    "dataset-hub",
+    "机器学习",
+    "数据集",
+    "自然语言处理",
+    "大语言模型"
+  ],
+  "data_content": {
+    "en": [
+      "Dataset Hub - 100,000+ ML datasets with standardized access",
+      "Dataset Cards - Licensing, citation, and documentation",
+      "NLP Datasets - Text classification, QA, translation, etc.",
+      "Vision Datasets - Image classification, object detection, etc.",
+      "Audio Datasets - Speech recognition, audio classification",
+      "Multimodal - Image-text, video-text paired datasets",
+      "Python Library - Programmatic access with datasets package",
+      "Streaming - Memory-efficient data loading"
+    ],
+    "zh": [
+      "数据集中心 - 100,000+ 个 ML 数据集及标准化访问",
+      "数据集卡片 - 许可证、引用和文档",
+      "NLP 数据集 - 文本分类、问答、翻译等",
+      "视觉数据集 - 图像分类、目标检测等",
+      "音频数据集 - 语音识别、音频分类",
+      "多模态 - 图文、视频文本配对数据集",
+      "Python 库 - 通过 datasets 包编程访问",
+      "流式加载 - 内存高效的数据加载"
+    ]
+  }
+}

--- a/firstdata/sources/sectors/J-information-communication/papers-with-code-datasets.json
+++ b/firstdata/sources/sectors/J-information-communication/papers-with-code-datasets.json
@@ -1,0 +1,63 @@
+{
+  "id": "papers-with-code-datasets",
+  "name": {
+    "en": "Papers With Code Datasets",
+    "zh": "Papers With Code 数据集"
+  },
+  "description": {
+    "en": "Papers With Code is a community-curated resource linking machine learning papers with their code implementations and datasets. The datasets section catalogs over 8,000 ML datasets with standardized metadata, benchmarks, and direct links to academic papers. Each dataset includes task categories, evaluation metrics, and state-of-the-art results, making it an essential reference for ML researchers and practitioners.",
+    "zh": "Papers With Code 是一个社区策划的资源，将机器学习论文与其代码实现和数据集关联起来。数据集部分收录了超过 8,000 个 ML 数据集，提供标准化元数据、基准测试和学术论文直接链接。每个数据集都包含任务类别、评估指标和最先进的结果，是 ML 研究人员和从业者的重要参考资源。"
+  },
+  "website": "https://paperswithcode.com",
+  "data_url": "https://paperswithcode.com/datasets",
+  "api_url": "https://paperswithcode.com/api/v1/docs/",
+  "country": null,
+  "domains": [
+    "Machine Learning",
+    "Artificial Intelligence",
+    "Deep Learning",
+    "Natural Language Processing",
+    "Computer Vision",
+    "Reinforcement Learning"
+  ],
+  "geographic_scope": "global",
+  "update_frequency": "daily",
+  "authority_level": "research",
+  "tags": [
+    "machine-learning",
+    "datasets",
+    "benchmarks",
+    "deep-learning",
+    "nlp",
+    "computer-vision",
+    "academic-papers",
+    "code-implementations",
+    "sota",
+    "state-of-the-art",
+    "ml-research",
+    "ai-benchmarks",
+    "机器学习",
+    "数据集",
+    "基准测试"
+  ],
+  "data_content": {
+    "en": [
+      "Dataset Catalog - 8,000+ ML datasets with standardized metadata",
+      "Task Categories - Classification, detection, generation, etc.",
+      "Benchmark Results - State-of-the-art performance comparisons",
+      "Paper Links - Direct connections to academic publications",
+      "Code Implementations - Links to GitHub repositories",
+      "Evaluation Metrics - Standard metrics for each task",
+      "Leaderboards - Ranked model performance tables"
+    ],
+    "zh": [
+      "数据集目录 - 8,000+ 个 ML 数据集及标准化元数据",
+      "任务类别 - 分类、检测、生成等",
+      "基准测试结果 - 最先进性能对比",
+      "论文链接 - 学术出版物直接链接",
+      "代码实现 - GitHub 仓库链接",
+      "评估指标 - 每个任务的标准指标",
+      "排行榜 - 模型性能排名表"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds two essential AI/ML data source entries:

### 1. Papers With Code Datasets
- **URL:** https://paperswithcode.com/datasets
- **Authority Level:** research
- **Highlights:**
  - 8,000+ ML datasets with standardized metadata
  - Links to academic papers and code implementations
  - Benchmark results and leaderboards
  - Has API

### 2. Hugging Face Datasets
- **URL:** https://huggingface.co/datasets
- **Authority Level:** market
- **Highlights:**
  - 100,000+ datasets (largest open ML dataset hub)
  - Python `datasets` library for programmatic access
  - Covers NLP, vision, audio, multimodal
  - Standardized dataset cards with licensing

## Checklist
- [x] JSON follows schema
- [x] URLs verified
- [x] Bilingual (en/zh) descriptions
- [x] Appropriate authority_level assigned

---
Submitted by: Claw (via OpenClaw)
Related Issue: #4