### PR TITLE
feat(badges): move badges to assets/ and use English labels

### DIFF
--- a/.github/workflows/update-indexes.yml
+++ b/.github/workflows/update-indexes.yml
@@ -59,6 +59,6 @@ jobs:
         run: |
           git config user.name "firstdata[bot]"
           git config user.email "firstdata@mininglamp.com"
-          git add firstdata/indexes/ firstdata/badges/
+          git add firstdata/indexes/ assets/badges/
           git diff --cached --quiet || git commit -m "chore(indexes): auto-update indexes"
           git push

--- a/README.en.md
+++ b/README.en.md
@@ -7,10 +7,10 @@ English | **[中文](README.md)** | **[日本語](README.ja.md)**
 **The World's Most Comprehensive, Authoritative, and Structured Open Data Source Repository**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Data Sources](https://img.shields.io/badge/Sources-132%2F1000+-blue.svg)](tasks/README.md)
-[![Progress](https://img.shields.io/badge/Progress-13%25-yellow.svg)](ROADMAP.md)
+[![Data Sources](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/assets/badges/sources-count.json)](firstdata/indexes/statistics.json)
+[![Progress](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/assets/badges/progress.json)](firstdata/indexes/statistics.json)
 [![Authority](https://img.shields.io/badge/Authority-Government%20%26%20International%20First-brightgreen.svg)](#)
-[![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](firstdata-mcp/)
+[![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](https://firstdata.deepminer.com.cn/)
 
 ---
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -7,10 +7,10 @@
 **世界で最も包括的で、権威的で、構造化されたオープンデータソースリポジトリ**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Data Sources](https://img.shields.io/badge/Sources-132%2F1000+-blue.svg)](tasks/README.md)
-[![Progress](https://img.shields.io/badge/Progress-13%25-yellow.svg)](ROADMAP.md)
+[![Data Sources](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/assets/badges/sources-count.json)](firstdata/indexes/statistics.json)
+[![Progress](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/assets/badges/progress.json)](firstdata/indexes/statistics.json)
 [![Authority](https://img.shields.io/badge/Authority-Government%20%26%20International%20First-brightgreen.svg)](#)
-[![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](firstdata-mcp/)
+[![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](https://firstdata.deepminer.com.cn/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 **The World's Most Comprehensive, Authoritative, and Structured Open Data Source Repository**
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![数据源数量](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/firstdata/badges/sources-count.json)](firstdata/indexes/statistics.json)
-[![完成进度](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/firstdata/badges/progress.json)](firstdata/indexes/statistics.json)
-[![权威性](https://img.shields.io/badge/权威性-政府与国际组织优先-brightgreen.svg)](#)
-[![MCP服务器](https://img.shields.io/badge/MCP-AI智能搜索-purple.svg)](firstdata-mcp/)
+[![Data Sources](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/assets/badges/sources-count.json)](firstdata/indexes/statistics.json)
+[![Progress](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/ningzimu/FirstData/main/assets/badges/progress.json)](firstdata/indexes/statistics.json)
+[![Authority](https://img.shields.io/badge/Authority-Government%20%26%20International%20First-brightgreen.svg)](#)
+[![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](https://firstdata.deepminer.com.cn/)
 
 ---
 

--- a/assets/badges/progress.json
+++ b/assets/badges/progress.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "label": "进度",
+  "label": "progress",
   "message": "13%",
   "color": "yellow"
 }

--- a/assets/badges/sources-count.json
+++ b/assets/badges/sources-count.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "label": "数据源",
+  "label": "sources",
   "message": "133/1000+",
   "color": "blue"
 }

--- a/scripts/build_indexes.py
+++ b/scripts/build_indexes.py
@@ -9,7 +9,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent
 SOURCES_DIR = REPO_ROOT / "firstdata" / "sources"
 INDEXES_DIR = REPO_ROOT / "firstdata" / "indexes"
-BADGES_DIR = REPO_ROOT / "firstdata" / "badges"
+BADGES_DIR = REPO_ROOT / "assets" / "badges"
 
 SCHEMA_VERSION = "2.0"
 TARGET_TOTAL = 1000
@@ -150,7 +150,7 @@ def build_badges(sources: list[dict]) -> list[tuple[Path, dict]]:
             BADGES_DIR / "sources-count.json",
             {
                 "schemaVersion": 1,
-                "label": "数据源",
+                "label": "sources",
                 "message": f"{total}/{TARGET_TOTAL}+",
                 "color": "blue",
             },
@@ -159,7 +159,7 @@ def build_badges(sources: list[dict]) -> list[tuple[Path, dict]]:
             BADGES_DIR / "progress.json",
             {
                 "schemaVersion": 1,
-                "label": "进度",
+                "label": "progress",
                 "message": f"{pct}%",
                 "color": color,
             },


### PR DESCRIPTION
## Summary

- Move `firstdata/badges/` to `assets/badges/` for better static asset organization
- Change badge labels from Chinese to English (`sources`, `progress`)
- Update static badge URLs in `README.md` to use English text
- Sync badge alt text across `README.md`, `README.en.md`, `README.ja.md`
- Update `scripts/build_indexes.py` and `update-indexes.yml` to reflect new path

## Test plan

- [x] `scripts/build_indexes.py` generates badge files to correct path `assets/badges/`
- [x] All three README files reference consistent English badge labels
- [x] `update-indexes.yml` commits to correct path `assets/badges/`