### PR TITLE
ci(workflows): integrate claude-review into validation pipeline and add interactive Claude Action

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,51 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--model ${{ secrets.CLAUDE_MODEL }} --max-turns 100 --allowedTools "Bash"'
+          additional_permissions: |
+            actions: read
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr:*)'
+

--- a/.github/workflows/validate-sources.yml
+++ b/.github/workflows/validate-sources.yml
@@ -2,6 +2,7 @@ name: Validate Data Sources
 
 on:
   pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
     paths:
       - "firstdata/sources/**/*.json"
       - "firstdata/schemas/datasource-schema.json"
@@ -41,3 +42,27 @@ jobs:
 
       - name: Check for duplicate IDs
         run: uv run python scripts/check_ids.py
+
+  claude-review:
+    needs: validate
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_args: '--model ${{ secrets.CLAUDE_MODEL }} --max-turns 100 --allowedTools "Bash"'
+          prompt: '/review Review this PR and post your review as a PR comment using `gh pr comment`. Reply in the same language used in the PR (title, description, and comments).'
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}


### PR DESCRIPTION
## Summary

- Add `claude.yml` workflow to support `@claude` mentions in issues/PRs for interactive Claude Code assistance
- Merge standalone `claude-code-review.yml` into `validate-sources.yml`, removing the redundant separate workflow
- `claude-review` job now depends on `validate` via `needs: validate`, ensuring data source validation must pass before Claude reviews the PR
- Add PR trigger types (`opened`, `synchronize`, `ready_for_review`, `reopened`) to align with the merged review workflow

## Pipeline Flow

```
protect-schema → validate → claude-review
```

## Test plan

- [ ] Open a PR that modifies `firstdata/sources/**/*.json` and verify all three jobs run in sequence
- [ ] Verify `claude-review` is skipped when `validate` fails
- [ ] Comment `@claude` on an issue or PR to verify `claude.yml` triggers correctly