### PR TITLE
fix(workflows): filter bot actors and mark claude-review as non-blocking

### DIFF
--- a/.github/workflows/validate-sources.yml
+++ b/.github/workflows/validate-sources.yml
@@ -45,7 +45,7 @@ jobs:
 
   claude-review:
     needs: validate
-    if: github.actor_type != 'Bot'
+    if: github.event.sender.type != 'Bot'
     continue-on-error: true
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Summary

- Filter out bot actors (`github.event.sender.type != 'Bot'`) to prevent claude-review from triggering on bot pushes
- Add `continue-on-error: true` so claude-review failure won't block the overall workflow result

## Context

PR #14 merged the claude-review job into validate-sources.yml, but it failed when triggered by bot actors (claude bot pushing to PRs).