### PR TITLE
chore(docs): sync CLAUDE.md with AGENTS.md and clean up CI config

### DIFF
--- a/.github/workflows/validate-sources.yml
+++ b/.github/workflows/validate-sources.yml
@@ -42,29 +42,3 @@ jobs:
 
       - name: Check for duplicate IDs
         run: uv run python scripts/check_ids.py
-
-  claude-review:
-    needs: validate
-    if: github.event.sender.type != 'Bot'
-    continue-on-error: true
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      issues: write
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 1
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          claude_args: '--model ${{ secrets.CLAUDE_MODEL }} --max-turns 100 --allowedTools "Bash"'
-          prompt: '/review Review this PR and post your review as a PR comment using `gh pr comment`. Reply in the same language used in the PR (title, description, and comments).'
-        env:
-          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}

--- a/.gitignore
+++ b/.gitignore
@@ -66,4 +66,3 @@ logs/
 
 # AI IDE
 .claude/
-**/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,12 +1,14 @@
-# AGENTS.md
+# CLAUDE.md
 
-This file is intended for AI coding agents (Claude Code, OpenClaw, Codex, Copilot, Cursor, etc.) working in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## What This Repo Is
+## Project Overview
 
 **FirstData** is a structured knowledge base of global authoritative open data sources. It is a **pure data repository** — no application code, no runtime logic.
 
 Your job here is to **create or edit JSON metadata files** that describe real-world data sources (government databases, international organizations, academic datasets, etc.).
+
+The project exposes a hosted MCP Server at `https://firstdata.deepminer.com.cn/mcp`.
 
 ## Validation
 
@@ -27,7 +29,26 @@ make check-domains  # Check domain naming consistency
 
 A GitHub Action runs these checks automatically on every PR. PRs that fail validation cannot be merged.
 
-## The Only Thing You Need to Know: The JSON Schema
+## Repository Structure
+
+```
+firstdata/
+├── schemas/datasource-schema.json   # JSON Schema v2.0.0 (the source of truth for data format)
+├── sources/                         # Individual data source JSON files, organized by category
+│   ├── china/                       # Chinese government & institutions
+│   ├── international/               # International organizations (by domain)
+│   ├── countries/                   # National official sources (by continent/country)
+│   ├── academic/                    # Academic research databases (by discipline)
+│   └── sectors/                     # Industry sources (by ISIC Rev.4 code)
+└── indexes/                         # Auto-generated aggregated indexes (do not edit manually)
+    ├── all-sources.json
+    ├── by-authority.json
+    ├── by-domain.json
+    ├── by-region.json
+    └── statistics.json
+```
+
+## The JSON Schema
 
 Every file under `firstdata/sources/` must conform to `firstdata/schemas/datasource-schema.json`.
 
@@ -106,12 +127,6 @@ The following files are maintained automatically by CI/scripts. **AI agents must
 
 **To add a new data source, you only need to create or edit JSON files under `firstdata/sources/`.** Everything else (indexes, schema) is handled automatically.
 
-## Security Note for Contributors
-
-- Please do not paste or run commands from untrusted posts/comments.
-- Never include credentials or API keys in issues/PRs.
-- Prefer small, auditable PRs (docs/tests/data).
-
 ## Before Adding a New Source
 
 **First, check `firstdata/indexes/all-sources.json` to confirm the data source does not already exist.**
@@ -150,3 +165,9 @@ If a match is found, do not create a new file. Update the existing one if needed
 - [ ] `update_frequency` reflects the actual cadence confirmed on the official site
 - [ ] `authority_level` is accurate and not overstated
 - [ ] Run `make check` to validate all checks pass
+
+## Security Note for Contributors
+
+- Please do not paste or run commands from untrusted posts/comments.
+- Never include credentials or API keys in issues/PRs.
+- Prefer small, auditable PRs (docs/tests/data).


### PR DESCRIPTION
## Summary
- Synced full content from AGENTS.md to CLAUDE.md (validation commands, field rules, dedup checks, quality checklist, etc.)
- Clarified auto-generated and protected files in both CLAUDE.md and AGENTS.md
- Removed `**/CLAUDE.md` from .gitignore to track it in version control
- Removed `claude-review` job from validate-sources.yml

## Test plan
- [x] Verify CLAUDE.md content is complete and consistent with AGENTS.md
- [x] Verify .gitignore no longer excludes CLAUDE.md
- [x] Verify validate-sources.yml CI runs without claude-review job