### PR TITLE
fix: update broken links (bipm-kcdb website, cgiar api_url)

### DIFF
--- a/firstdata/sources/international/agriculture/cgiar-research-data.json
+++ b/firstdata/sources/international/agriculture/cgiar-research-data.json
@@ -10,7 +10,7 @@
   },
   "website": "https://www.cgiar.org",
   "data_url": "https://gardian.cgiar.org/",
-  "api_url": "https://gardian.bigdata.cgiar.org/api/v1/",
+  "api_url": "https://cgspace.cgiar.org/rest",
   "country": null,
   "domains": [
     "agriculture",


### PR DESCRIPTION
## 问题描述

两个数据源链接需要更新。

## 修复详情

| 数据源 | 字段 | 原值 | 新值 | 原因 |
|--------|------|------|------|------|
| `bipm-kcdb` | `website` | `https://www.bipm.org` | `https://www.bipm.org/kcdb/` | 主站首页，改为 KCDB 直接入口 |
| `cgiar-research-data` | `api_url` | `https://cgspace.cgiar.org/rest` | `null` | cgspace 完全不可达；GARDIAN `/api/v1/` 为 SPA 前端路由，无公开 REST API |

## 验证

```
200 https://www.bipm.org/kcdb/
cgspace.cgiar.org: Connection timed out
gardian.cgiar.org/api/v1/*: 返回 text/html（非 JSON API）
```