### PR TITLE
fix: set cgiar-research-data api_url to null

### DIFF
--- a/firstdata/sources/international/agriculture/cgiar-research-data.json
+++ b/firstdata/sources/international/agriculture/cgiar-research-data.json
@@ -10,7 +10,7 @@
   },
   "website": "https://www.cgiar.org",
   "data_url": "https://gardian.cgiar.org/",
-  "api_url": "https://cgspace.cgiar.org/rest",
+  "api_url": null,
   "country": null,
   "domains": [
     "agriculture",


### PR DESCRIPTION
## 问题描述

`cgiar-research-data` 的 `api_url` 指向已失效的 CGSpace REST API。

## 修复详情

| 字段 | 原值 | 新值 | 原因 |
|------|------|------|------|
| `api_url` | `https://cgspace.cgiar.org/rest` | `null` | cgspace 连接超时；GARDIAN `/api/v1/` 为 SPA 前端路由，非 REST API |

## 验证

- `cgspace.cgiar.org`：连接超时（经沙盒 + 服务器双重确认）
- `gardian.cgiar.org/api/v1/*`：所有路径返回 `text/html`（SPA），无 JSON API
- CGIAR 目前无公开 REST API 端点，暂设 null，待官方提供后更新