### PR TITLE
feat: add china-mwr (水利部) and china-moa (农业农村部) data sources

### DIFF
--- a/firstdata/sources/china/economy/agriculture/china-moa.json
+++ b/firstdata/sources/china/economy/agriculture/china-moa.json
@@ -1,0 +1,88 @@
+{
+  "id": "china-moa",
+  "name": {
+    "en": "Ministry of Agriculture and Rural Affairs of China - Agricultural Statistics",
+    "zh": "中华人民共和国农业农村部农业统计"
+  },
+  "description": {
+    "en": "Official agricultural statistics and rural economy data published by China's Ministry of Agriculture and Rural Affairs (MARA), covering crop production, livestock and aquaculture, agricultural inputs, rural household income, and agricultural mechanization. Includes annual China Agricultural Development Reports and statistical yearbooks on agriculture and rural development.",
+    "zh": "中华人民共和国农业农村部发布的官方农业统计和农村经济数据，涵盖农作物产量、畜牧水产、农业投入品、农村居民收入及农业机械化水平。包括年度《中国农业发展报告》和农业农村统计年报。"
+  },
+  "website": "http://www.moa.gov.cn/",
+  "data_url": "http://www.moa.gov.cn/nybgb/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "domains": [
+    "agriculture",
+    "economics",
+    "statistics"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "annual",
+  "tags": [
+    "农业农村部",
+    "农业统计",
+    "agriculture statistics",
+    "Ministry of Agriculture and Rural Affairs",
+    "MARA",
+    "粮食产量",
+    "grain production",
+    "农业发展报告",
+    "agricultural development report",
+    "农村经济",
+    "rural economy",
+    "农作物",
+    "crops",
+    "畜牧业",
+    "livestock",
+    "水产品",
+    "aquaculture",
+    "农民收入",
+    "farmer income",
+    "化肥",
+    "fertilizer",
+    "农药",
+    "pesticides",
+    "农业机械化",
+    "agricultural mechanization",
+    "耕地面积",
+    "arable land",
+    "农业生产",
+    "agricultural production",
+    "乡村振兴",
+    "rural revitalization",
+    "农业年报",
+    "agricultural yearbook"
+  ],
+  "data_content": {
+    "en": [
+      "Annual crop production data - grain, cotton, oilseeds, vegetables, fruits by province",
+      "Livestock statistics - pigs, cattle, sheep, poultry breeding and slaughter data",
+      "Aquaculture and fishery production statistics",
+      "Agricultural input usage - fertilizers, pesticides, seeds, agricultural film",
+      "Agricultural mechanization - tractor and machinery ownership and usage",
+      "Rural household income and expenditure statistics",
+      "Arable land and cultivated area by crop type",
+      "Agricultural disaster and crop loss statistics",
+      "Rural labor force and agricultural employment data",
+      "Agricultural product prices and market monitoring",
+      "China Agricultural Development Report (annual)",
+      "Agricultural and Rural Statistics Annual Report"
+    ],
+    "zh": [
+      "年度农作物产量数据 - 粮食、棉花、油料、蔬菜、水果分省统计",
+      "畜牧业统计 - 生猪、牛、羊、禽类存栏和出栏数据",
+      "水产养殖和捕捞产量统计",
+      "农业投入品使用 - 化肥、农药、种子、农膜",
+      "农业机械化 - 拖拉机和农机拥有量及使用情况",
+      "农村居民收入与支出统计",
+      "耕地面积和分作物播种面积",
+      "农业灾害和农作物损失统计",
+      "农村劳动力和农业就业数据",
+      "农产品价格和市场监测",
+      "年度《中国农业发展报告》",
+      "农业农村统计年报"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/water/china-mwr.json
+++ b/firstdata/sources/china/resources/water/china-mwr.json
@@ -1,0 +1,84 @@
+{
+  "id": "china-mwr",
+  "name": {
+    "en": "Ministry of Water Resources of China - Water Resources Statistics",
+    "zh": "中华人民共和国水利部水资源统计"
+  },
+  "description": {
+    "en": "Official water resources statistics published by China's Ministry of Water Resources, covering water resources assessment, water supply and consumption, flood control, drought relief, irrigation, and hydraulic engineering development. Includes annual China Water Resources Bulletins and comprehensive statistical yearbooks on water conservancy.",
+    "zh": "中华人民共和国水利部发布的官方水资源统计数据，涵盖水资源调查评价、供用水量、防洪抗旱、灌溉面积及水利工程建设发展状况。包括年度《中国水资源公报》和水利统计年鉴。"
+  },
+  "website": "http://www.mwr.gov.cn/",
+  "data_url": "http://www.mwr.gov.cn/sj/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "domains": [
+    "environment",
+    "infrastructure",
+    "statistics"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "annual",
+  "tags": [
+    "水利部",
+    "水资源",
+    "water resources",
+    "Ministry of Water Resources",
+    "MWR",
+    "水资源公报",
+    "water resources bulletin",
+    "供水",
+    "water supply",
+    "用水量",
+    "water consumption",
+    "防洪",
+    "flood control",
+    "灌溉",
+    "irrigation",
+    "水利工程",
+    "hydraulic engineering",
+    "水库",
+    "reservoirs",
+    "河流",
+    "rivers",
+    "地下水",
+    "groundwater",
+    "降水量",
+    "precipitation",
+    "水利统计年鉴",
+    "water conservancy yearbook",
+    "旱情",
+    "drought",
+    "水文",
+    "hydrology"
+  ],
+  "data_content": {
+    "en": [
+      "Annual China Water Resources Bulletin - total water resources volume by region",
+      "Surface water and groundwater resources assessment",
+      "Water supply statistics by source type (surface water, groundwater, other)",
+      "Water consumption by sector (agriculture, industry, household, ecological)",
+      "Irrigation area and farmland irrigation statistics",
+      "Reservoir and dam statistics by type and capacity",
+      "Flood control and disaster relief data",
+      "Drought monitoring and relief statistics",
+      "Hydraulic engineering construction investment and progress",
+      "Rural water supply coverage and safe drinking water data",
+      "Water conservancy statistical yearbook (annual)"
+    ],
+    "zh": [
+      "年度《中国水资源公报》- 各地区水资源总量",
+      "地表水和地下水资源评价数据",
+      "分水源供水量统计（地表水、地下水、其他水源）",
+      "分行业用水量（农业、工业、生活、生态用水）",
+      "灌溉面积和耕地灌溉统计",
+      "水库大坝分类型和库容统计",
+      "防洪减灾数据",
+      "旱情监测与抗旱统计",
+      "水利工程建设投资与进度",
+      "农村供水覆盖率和安全饮水数据",
+      "水利统计年鉴（年度）"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Add two new authoritative Chinese government data sources:

### 1. china-mwr — Ministry of Water Resources (水利部)
- **Path**: `firstdata/sources/china/resources/water/china-mwr.json`
- **Coverage**: Water resources assessment, supply/consumption statistics, flood control, irrigation area, hydraulic engineering
- **Key dataset**: Annual China Water Resources Bulletin (中国水资源公报)
- **Domains**: environment, infrastructure, statistics
- **Update frequency**: Annual

### 2. china-moa — Ministry of Agriculture and Rural Affairs (农业农村部)
- **Path**: `firstdata/sources/china/economy/agriculture/china-moa.json`
- **Coverage**: Crop production, livestock, aquaculture, agricultural inputs, rural household income, mechanization
- **Key dataset**: China Agricultural Development Report (中国农业发展报告)
- **Domains**: agriculture, economics, statistics
- **Update frequency**: Annual

## Validation
- ✅ `make validate` — all 158 IDs pass schema validation
- ✅ `make check-ids` — no duplicate IDs
- ✅ `make check-domains` — domain consistency confirmed
- ✅ URLs verified accessible (moa.gov.cn confirmed 200 OK)
- ✅ No existing entries for these sources in indexes