### PR TITLE
feat: add china-safe and china-sse data sources

### DIFF
--- a/firstdata/sources/china/finance/forex/china-safe.json
+++ b/firstdata/sources/china/finance/forex/china-safe.json
@@ -1,0 +1,62 @@
+{
+  "id": "china-safe",
+  "name": {
+    "en": "State Administration of Foreign Exchange of China",
+    "zh": "国家外汇管理局",
+    "native": "国家外汇管理局"
+  },
+  "description": {
+    "en": "The State Administration of Foreign Exchange (SAFE) is China's foreign exchange regulatory authority responsible for drafting regulations on foreign exchange market supervision and managing China's foreign exchange reserves. It publishes authoritative statistics on foreign exchange reserves, balance of payments, international investment position, cross-border capital flows, and exchange rate data.",
+    "zh": "国家外汇管理局（外汇局）是中国外汇市场的监管机构，负责管理国家外汇储备。发布外汇储备规模、国际收支、国际投资头寸、跨境资本流动和汇率等权威统计数据。"
+  },
+  "website": "http://www.safe.gov.cn",
+  "data_url": "http://www.safe.gov.cn/safe/tjsj/index.html",
+  "api_url": null,
+  "country": "CN",
+  "domains": [
+    "finance",
+    "economics",
+    "international_trade"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "authority_level": "government",
+  "tags": [
+    "china",
+    "foreign-exchange",
+    "forex",
+    "reserves",
+    "balance-of-payments",
+    "international-investment",
+    "cross-border",
+    "capital-flows",
+    "exchange-rate",
+    "外汇",
+    "外汇储备",
+    "国际收支",
+    "跨境资本",
+    "人民币"
+  ],
+  "data_content": {
+    "en": [
+      "Foreign Exchange Reserves - Monthly data on China's official foreign exchange reserve levels",
+      "Balance of Payments - Current account, capital account, and financial account statistics",
+      "International Investment Position - China's external assets and liabilities",
+      "Cross-border Capital Flows - FDI inflows/outflows, portfolio investment, and other capital flows",
+      "Exchange Rate Data - RMB central parity rates and exchange rate statistics",
+      "Foreign Exchange Market - Trading volumes and market structure data",
+      "Banks' Foreign Exchange Assets and Liabilities - Banking sector foreign exchange positions",
+      "External Debt Statistics - China's total external debt by sector and maturity"
+    ],
+    "zh": [
+      "外汇储备规模 - 中国官方外汇储备月度数据",
+      "国际收支 - 经常账户、资本账户和金融账户统计",
+      "国际投资头寸 - 中国对外资产和负债状况",
+      "跨境资本流动 - 外商直接投资、证券投资和其他资本流动",
+      "汇率数据 - 人民币中间价和汇率统计",
+      "外汇市场 - 外汇市场交易量和市场结构数据",
+      "银行业外汇资产负债 - 银行业外汇头寸",
+      "外债统计 - 按部门和期限分类的中国外债总量"
+    ]
+  }
+}

--- a/firstdata/sources/china/finance/securities/china-sse.json
+++ b/firstdata/sources/china/finance/securities/china-sse.json
@@ -1,0 +1,65 @@
+{
+  "id": "china-sse",
+  "name": {
+    "en": "Shanghai Stock Exchange",
+    "zh": "上海证券交易所",
+    "native": "上海证券交易所"
+  },
+  "description": {
+    "en": "The Shanghai Stock Exchange (SSE) is one of China's two major stock exchanges and one of the largest in the world by market capitalization. It provides comprehensive real-time and historical market data including equity trading, bond markets, funds, derivatives, and company disclosure information. SSE hosts the main board and the STAR Market (Science and Technology Innovation Board) for high-tech enterprises.",
+    "zh": "上海证券交易所（上交所）是中国两大证券交易所之一，也是全球市值最大的证券交易所之一。提供股票交易、债券市场、基金、衍生品及上市公司信息披露的全面实时和历史市场数据。上交所设有主板和面向科创企业的科创板。"
+  },
+  "website": "http://www.sse.com.cn",
+  "data_url": "http://www.sse.com.cn/market/stockdata/statistic/",
+  "api_url": null,
+  "country": "CN",
+  "domains": [
+    "finance",
+    "securities",
+    "capital_markets"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "daily",
+  "authority_level": "market",
+  "tags": [
+    "china",
+    "stock-exchange",
+    "shanghai",
+    "A-shares",
+    "equities",
+    "bonds",
+    "ETF",
+    "STAR-market",
+    "market-data",
+    "listed-companies",
+    "securities",
+    "上交所",
+    "上海证券交易所",
+    "A股",
+    "股票",
+    "科创板",
+    "债券"
+  ],
+  "data_content": {
+    "en": [
+      "Equity Market Statistics - Daily trading volume, market capitalization, and price indices (SSE Composite, SSE 50, SSE 180)",
+      "Listed Companies - Total number, sector breakdown, financial disclosures, and annual reports",
+      "Bond Market - Government bonds, corporate bonds, convertible bonds trading data",
+      "Fund Market - ETFs, mutual funds, REITs listing and trading statistics",
+      "STAR Market - Science and Technology Innovation Board company listings and trading data",
+      "Derivatives - Stock options trading volumes and open interest",
+      "Market Overview - Total accounts, investor structure, and market activity",
+      "Historical Data - Daily, monthly, and annual historical market statistics"
+    ],
+    "zh": [
+      "股票市场统计 - 日交易量、市值和价格指数（上证综指、上证50、上证180）",
+      "上市公司 - 总数、行业分布、财务披露和年报",
+      "债券市场 - 国债、公司债、可转债交易数据",
+      "基金市场 - ETF、公募基金、REITs上市和交易统计",
+      "科创板 - 科技创新企业上市和交易数据",
+      "衍生品 - 股票期权交易量和持仓量",
+      "市场概况 - 账户总数、投资者结构和市场活跃度",
+      "历史数据 - 每日、每月、每年历史市场统计数据"
+    ]
+  }
+}


### PR DESCRIPTION
## New Data Sources

### china-safe — 国家外汇管理局 (State Administration of Foreign Exchange)
- **File**: `firstdata/sources/china/finance/forex/china-safe.json`
- **Authority**: Government
- **Domains**: finance, economics, international_trade
- **Coverage**: Foreign exchange reserves, balance of payments, international investment position, cross-border capital flows, exchange rate data
- **Update Frequency**: Monthly
- **Website**: http://www.safe.gov.cn ✅
- **Data URL**: http://www.safe.gov.cn/safe/tjsj/index.html ✅

### china-sse — 上海证券交易所 (Shanghai Stock Exchange)
- **File**: `firstdata/sources/china/finance/securities/china-sse.json`
- **Authority**: Market
- **Domains**: finance, securities, capital_markets
- **Coverage**: A-share equity data, STAR Market, bond market, ETFs, derivatives, listed company statistics
- **Update Frequency**: Daily
- **Website**: http://www.sse.com.cn ✅
- **Data URL**: http://www.sse.com.cn/market/stockdata/statistic/ ✅

## Validation
- ✅ `make validate` passed
- ✅ `make check-ids` passed (158 unique IDs)
- ✅ `make check-domains` passed
- ✅ Both URLs verified accessible