### PR TITLE
feat: add SZSE (深圳证券交易所) and CNNIC (中国互联网络信息中心) data sources

### DIFF
--- a/firstdata/sources/china/finance/securities/szse.json
+++ b/firstdata/sources/china/finance/securities/szse.json
@@ -1,0 +1,64 @@
+{
+  "id": "china-szse",
+  "name": {
+    "en": "Shenzhen Stock Exchange",
+    "zh": "深圳证券交易所",
+    "native": "深圳证券交易所"
+  },
+  "description": {
+    "en": "The Shenzhen Stock Exchange (SZSE) is one of China's two major stock exchanges, home to the ChiNext board (创业板) for innovative growth companies and the Small and Medium Enterprise (SME) board. It provides comprehensive market data including stock trading statistics, listed company information, bond market data, fund data, index data, and market summaries.",
+    "zh": "深圳证券交易所是中国两大主要证券交易所之一，设有面向创新成长型企业的创业板和中小企业板。提供全面的市场数据，包括股票交易统计、上市公司信息、债券市场数据、基金数据、指数数据和市场总览。"
+  },
+  "website": "https://www.szse.cn",
+  "data_url": "https://www.szse.cn/market/trend/index.html",
+  "api_url": "https://www.szse.cn/api/report/ShowReport/data",
+  "authority_level": "government",
+  "country": "CN",
+  "domains": [
+    "finance",
+    "securities",
+    "capital_markets"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "daily",
+  "tags": [
+    "china",
+    "shenzhen",
+    "stock-exchange",
+    "szse",
+    "chinext",
+    "创业板",
+    "中小板",
+    "深交所",
+    "equity",
+    "securities",
+    "a-shares",
+    "etf",
+    "bonds",
+    "index"
+  ],
+  "data_content": {
+    "en": [
+      "Market Overview - Daily trading volume, market capitalization, number of listed companies, and composite index",
+      "ChiNext Board (创业板) - Trading data, listings, and market statistics for innovative growth companies",
+      "Stock Trading Data - Real-time and historical prices, volume, turnover rate, and sector statistics",
+      "Listed Companies - Company profiles, financial disclosures, prospectuses, and annual reports",
+      "Bond Market - Corporate bonds, convertible bonds, asset-backed securities trading data",
+      "Fund Data - ETF, LOF, and REITs trading volume and net asset value statistics",
+      "Index Data - SZSE Component Index, ChiNext Index, and other derived indices",
+      "Industry Statistics - Trading data segmented by CSRC industry classification",
+      "Investor Statistics - Number of accounts, institutional vs. retail investor breakdown"
+    ],
+    "zh": [
+      "市场总览 - 每日成交量、市值、上市公司数量和综合指数",
+      "创业板 - 创新成长型企业交易数据、上市情况和市场统计",
+      "股票交易数据 - 实时和历史价格、成交量、换手率及行业统计",
+      "上市公司 - 公司概况、财务披露、招股说明书和年报",
+      "债券市场 - 公司债、可转债、资产支持证券交易数据",
+      "基金数据 - ETF、LOF和REITs成交量及净值统计",
+      "指数数据 - 深证成份指数、创业板指数及其他衍生指数",
+      "行业统计 - 按证监会行业分类的交易数据",
+      "投资者统计 - 账户数量、机构与散户投资者结构"
+    ]
+  }
+}

--- a/firstdata/sources/china/technology/internet/cnnic.json
+++ b/firstdata/sources/china/technology/internet/cnnic.json
@@ -1,0 +1,64 @@
+{
+  "id": "china-cinic",
+  "name": {
+    "en": "China Internet Network Information Center",
+    "zh": "中国互联网络信息中心",
+    "native": "中国互联网络信息中心"
+  },
+  "description": {
+    "en": "China Internet Network Information Center (CNNIC) is the state network information center under the Ministry of Industry and Information Technology. It publishes the authoritative Statistical Report on China's Internet Development (中国互联网络发展状况统计报告), released twice a year, covering internet users, broadband penetration, mobile internet, e-commerce, online services, and domain name registration statistics in China.",
+    "zh": "中国互联网络信息中心（CNNIC）是工业和信息化部下属的国家互联网络信息中心。每年发布两次《中国互联网络发展状况统计报告》，覆盖中国网民规模、宽带普及率、移动互联网、电子商务、网络服务和域名注册统计数据。"
+  },
+  "website": "https://www.cnnic.cn",
+  "data_url": "https://www.cnnic.cn/hlwfzyj/hlwxzbg/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "domains": [
+    "technology",
+    "telecommunications",
+    "digital_economy"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "irregular",
+  "tags": [
+    "china",
+    "internet",
+    "cnnic",
+    "中国互联网",
+    "网民",
+    "互联网统计",
+    "宽带",
+    "移动互联网",
+    "电子商务",
+    "域名",
+    "digital",
+    "broadband",
+    "e-commerce",
+    "internet-users"
+  ],
+  "data_content": {
+    "en": [
+      "Internet Users - Total number of internet users, internet penetration rate, urban vs. rural breakdown",
+      "Mobile Internet - Mobile internet users, smartphone usage, mobile app statistics",
+      "Broadband - Fixed broadband subscriptions, speeds, and household penetration rates",
+      "E-Commerce - Online shopping users, transaction volumes, cross-border e-commerce",
+      "Online Services - Online banking, online government services, online healthcare, online education usage",
+      "Domain Names - .CN domain registrations, IP address allocations, IPv6 adoption",
+      "Internet Infrastructure - Bandwidth capacity, international connectivity, internet exchange points",
+      "Social Media - Instant messaging, social network usage statistics",
+      "Digital Economy - Internet economic indicators, platform economy data"
+    ],
+    "zh": [
+      "网民规模 - 网民总数、互联网普及率、城乡分布",
+      "移动互联网 - 手机网民规模、智能手机使用情况、移动应用统计",
+      "宽带接入 - 固定宽带订阅数、网速和家庭普及率",
+      "网络购物 - 网络购物用户规模、交易规模、跨境电商数据",
+      "网络服务 - 网络银行、网络政务、网络医疗、网络教育使用情况",
+      "域名注册 - .CN域名注册量、IP地址分配、IPv6普及情况",
+      "互联网基础资源 - 带宽容量、国际互联网出口、互联网交换中心",
+      "社交媒体 - 即时通信、社交网络使用统计",
+      "数字经济 - 互联网经济指标、平台经济数据"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds two new Chinese authoritative data sources:

### 1. china-szse — Shenzhen Stock Exchange (深圳证券交易所)
- **Path:** `firstdata/sources/china/finance/securities/szse.json`
- **Authority:** Government (national)
- **Scope:** National | Daily updates
- **Coverage:** ChiNext board (创业板), SME board, stock trading data, listed companies, bonds, ETFs, indices, investor statistics

### 2. china-cinic — China Internet Network Information Center (中国互联网络信息中心)
- **Path:** `firstdata/sources/china/technology/internet/cnnic.json`
- **Authority:** Government (national)
- **Scope:** National | Irregular (biannual report)
- **Coverage:** Internet users, mobile internet, broadband, e-commerce, domain names, digital economy indicators

## Validation
- ✅ `make validate` — schema compliant
- ✅ `make check-ids` — no duplicate IDs (158 total unique)
- ✅ `make check-domains` — domain consistency OK
- ✅ URLs verified accessible