### PR TITLE
feat: add china-caac and eurostat data sources

### DIFF
--- a/firstdata/sources/china/economy/china-caac.json
+++ b/firstdata/sources/china/economy/china-caac.json
@@ -1,0 +1,62 @@
+{
+  "id": "china-caac",
+  "name": {
+    "en": "Civil Aviation Administration of China",
+    "zh": "中国民用航空局",
+    "native": "中国民用航空局"
+  },
+  "description": {
+    "en": "The Civil Aviation Administration of China (CAAC) is the government body responsible for civil aviation regulation and oversight in China. It publishes comprehensive civil aviation statistics including passenger and freight traffic, airline operations, airport throughput, flight safety records, and industry development data.",
+    "zh": "中国民用航空局（CAAC）是负责中国民用航空监管和管理的政府机构。发布全面的民航统计数据，包括旅客和货邮运输量、航空公司运营、机场吞吐量、飞行安全记录和行业发展数据。"
+  },
+  "website": "https://www.caac.gov.cn",
+  "data_url": "https://www.caac.gov.cn/XXGK/XXGK/TJSJ/index.html",
+  "api_url": null,
+  "country": "CN",
+  "authority_level": "government",
+  "domains": [
+    "transportation",
+    "aviation",
+    "statistics",
+    "economics"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "china",
+    "civil-aviation",
+    "caac",
+    "民航",
+    "航空统计",
+    "passenger-traffic",
+    "freight-traffic",
+    "airport",
+    "airline",
+    "aviation-safety",
+    "government"
+  ],
+  "data_content": {
+    "en": [
+      "Passenger Traffic - Total civil aviation passenger volume, load factor, and passenger kilometers",
+      "Freight and Mail Traffic - Air cargo and mail transport volumes and ton-kilometers",
+      "Airport Throughput - Passenger, cargo, and aircraft movements at major airports",
+      "Airline Operations - Fleet size, routes, flight frequency, and on-time performance",
+      "Flight Safety - Accident and incident statistics, safety inspection records",
+      "Civil Aviation Industry Statistics - Revenue, investment, and employment in the sector",
+      "International Routes - Cross-border passenger and cargo traffic by country",
+      "General Aviation - Non-commercial aviation operations and fleet data",
+      "Annual Civil Aviation Development Statistics Bulletin - comprehensive yearly report"
+    ],
+    "zh": [
+      "旅客运输 - 民航旅客总运输量、客座率和旅客周转量",
+      "货邮运输 - 航空货物和邮件运输量及货邮周转量",
+      "机场吞吐量 - 主要机场旅客、货物和飞机起降量",
+      "航空公司运营 - 机队规模、航线、航班频次和正点率",
+      "飞行安全 - 事故和事件统计、安全检查记录",
+      "民航行业统计 - 行业营收、投资和就业情况",
+      "国际航线 - 按国家分类的跨境旅客和货运交通",
+      "通用航空 - 非商业性航空运营和机队数据",
+      "民航发展统计公报 - 综合年度报告"
+    ]
+  }
+}

--- a/firstdata/sources/international/economics/eurostat.json
+++ b/firstdata/sources/international/economics/eurostat.json
@@ -1,0 +1,77 @@
+{
+  "id": "eurostat",
+  "name": {
+    "en": "Eurostat - Statistical Office of the European Union",
+    "zh": "欧盟统计局",
+    "native": "Eurostat"
+  },
+  "description": {
+    "en": "Eurostat is the statistical office of the European Union, providing high-quality statistics on Europe. It produces comparable statistical information at European level and promotes the use of common statistical methods across EU member states. Data covers economics, population, social conditions, industry, trade, environment, and regional statistics for all 27 EU member states.",
+    "zh": "欧盟统计局（Eurostat）是欧盟的统计机构，提供有关欧洲的高质量统计数据。制作欧洲层面的可比统计信息，并推动欧盟成员国使用共同的统计方法。数据涵盖全部27个欧盟成员国的经济、人口、社会状况、工业、贸易、环境和区域统计。"
+  },
+  "website": "https://ec.europa.eu/eurostat",
+  "data_url": "https://ec.europa.eu/eurostat/databrowser/explore/all/all_themes",
+  "api_url": "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data/",
+  "country": null,
+  "authority_level": "international",
+  "domains": [
+    "economics",
+    "demographics",
+    "social",
+    "trade",
+    "environment",
+    "industry",
+    "agriculture"
+  ],
+  "geographic_scope": "regional",
+  "update_frequency": "monthly",
+  "tags": [
+    "europe",
+    "eu",
+    "eurostat",
+    "欧盟",
+    "欧洲统计",
+    "gdp",
+    "inflation",
+    "employment",
+    "trade",
+    "population",
+    "official-statistics",
+    "government",
+    "regional-statistics"
+  ],
+  "data_content": {
+    "en": [
+      "GDP and National Accounts - Gross domestic product, national income, and expenditure accounts for EU member states",
+      "Population and Demographics - Population size, age structure, fertility, mortality, and migration statistics",
+      "Employment and Labor Market - Employment rates, unemployment, working conditions, and labor costs by country",
+      "Prices and Inflation - Harmonised Index of Consumer Prices (HICP), producer prices, and purchasing power parities",
+      "International Trade - Intra-EU and extra-EU trade in goods and services by country and product",
+      "Industry and Energy - Industrial production indices, energy consumption, and production statistics",
+      "Agriculture and Food - Agricultural output, land use, farm structure, and food safety data",
+      "Environment and Climate - Greenhouse gas emissions, waste, water, and biodiversity indicators",
+      "Education and Training - Educational attainment, enrollment rates, and lifelong learning statistics",
+      "Health Statistics - Healthcare expenditure, life expectancy, causes of death, and health behaviors",
+      "Regional Statistics - NUTS-level data for sub-national regions across Europe",
+      "Digital Economy - Internet usage, e-commerce, and ICT adoption statistics",
+      "Government Finance - Public deficit, debt, revenue, and expenditure by country",
+      "Science and Technology - R&D expenditure, patent statistics, and innovation indicators"
+    ],
+    "zh": [
+      "GDP与国民账户 - 欧盟成员国国内生产总值、国民收入和支出账户",
+      "人口与人口统计 - 人口规模、年龄结构、生育率、死亡率和移民统计",
+      "就业与劳动市场 - 各国就业率、失业率、劳动条件和劳动力成本",
+      "价格与通货膨胀 - 协调消费者价格指数(HICP)、生产者价格和购买力平价",
+      "国际贸易 - 欧盟内部和对外商品及服务贸易（按国家和产品分类）",
+      "工业与能源 - 工业生产指数、能源消耗和生产统计",
+      "农业与食品 - 农业产值、土地利用、农场结构和食品安全数据",
+      "环境与气候 - 温室气体排放、废物、水资源和生物多样性指标",
+      "教育与培训 - 教育程度、入学率和终身学习统计",
+      "健康统计 - 医疗支出、预期寿命、死亡原因和健康行为",
+      "区域统计 - 欧洲各次国家地区的NUTS级数据",
+      "数字经济 - 互联网使用、电子商务和信息通信技术普及统计",
+      "政府财政 - 各国公共赤字、债务、收入和支出",
+      "科学与技术 - 研发支出、专利统计和创新指标"
+    ]
+  }
+}


### PR DESCRIPTION
Add 2 new data sources:

1. **china-caac** — 中国民用航空局 (Civil Aviation Administration of China)
2. **eurostat** — 欧盟统计局 (European Statistical Office)

QA reviewed by 明察 ✅