### PR TITLE
feat: add Spain INE and Italy ISTAT national statistics bureaus

### DIFF
--- a/firstdata/sources/countries/europe/italy/italy-istat.json
+++ b/firstdata/sources/countries/europe/italy/italy-istat.json
@@ -1,0 +1,47 @@
+{
+  "id": "italy-istat",
+  "name": {
+    "en": "Italian National Institute of Statistics (ISTAT)",
+    "zh": "意大利国家统计局",
+    "native": "Istituto Nazionale di Statistica"
+  },
+  "description": {
+    "en": "Italy's official national statistics institute, producing authoritative data on population, economy, society, and environment. Provides census data, national accounts, labor market statistics, consumer prices, and cross-sectoral surveys for Italy and its regions.",
+    "zh": "意大利官方国家统计机构，提供人口、经济、社会和环境领域的权威统计数据，包括人口普查、国民账户、劳动市场、消费者价格及跨部门调查。"
+  },
+  "website": "https://www.istat.it/en/",
+  "data_url": "https://esploradati.istat.it/databrowser/",
+  "api_url": "https://sdmx.istat.it/SDMXWS/rest/",
+  "authority_level": "government",
+  "country": "IT",
+  "domains": ["economics", "demographics", "social", "environment", "labor"],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "ISTAT", "Italy", "Italia", "statistics", "census", "CPI", "inflation",
+    "population", "employment", "GDP", "意大利", "统计", "人口", "通胀",
+    "劳动市场", "国民账户", "欧盟", "SDMX"
+  ],
+  "data_content": {
+    "en": [
+      "Population census and demographic projections",
+      "National accounts and GDP",
+      "Consumer price index and inflation",
+      "Labor force survey and employment",
+      "Industrial and construction output",
+      "External trade statistics",
+      "Environmental accounts",
+      "Regional statistics by Italian provinces"
+    ],
+    "zh": [
+      "人口普查与人口预测",
+      "国民账户与GDP",
+      "消费者价格指数与通货膨胀",
+      "劳动力调查与就业",
+      "工业与建筑产出",
+      "对外贸易统计",
+      "环境账户",
+      "意大利各省区域统计"
+    ]
+  }
+}

--- a/firstdata/sources/countries/europe/spain/spain-ine.json
+++ b/firstdata/sources/countries/europe/spain/spain-ine.json
@@ -1,0 +1,47 @@
+{
+  "id": "spain-ine",
+  "name": {
+    "en": "Instituto Nacional de Estadística (INE Spain)",
+    "zh": "西班牙国家统计局",
+    "native": "Instituto Nacional de Estadística"
+  },
+  "description": {
+    "en": "Spain's official national statistics institute, responsible for producing and disseminating economic, demographic, social, and environmental statistics. Covers census data, population surveys, CPI, industrial output, labor market statistics, and more.",
+    "zh": "西班牙官方国家统计机构，负责生产和传播经济、人口、社会和环境统计数据，涵盖人口普查、消费者价格指数、工业产出、劳动市场统计等。"
+  },
+  "website": "https://www.ine.es/en/index.htm",
+  "data_url": "https://www.ine.es/en/prensa/prensa_encuesta_en.htm",
+  "api_url": "https://servicios.ine.es/wstempus/js/en/OPERACIONES_DISPONIBLES",
+  "authority_level": "government",
+  "country": "ES",
+  "domains": ["economics", "demographics", "social", "environment", "labor"],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "INE", "Spain", "España", "statistics", "census", "CPI", "inflation",
+    "population", "employment", "GDP", "西班牙", "统计", "人口", "通胀",
+    "劳动市场", "国家统计", "欧盟"
+  ],
+  "data_content": {
+    "en": [
+      "Population census and projections",
+      "Consumer Price Index (CPI) and inflation",
+      "Labor force survey and unemployment",
+      "Industrial production index",
+      "GDP and national accounts",
+      "Agricultural, fishery, and forestry statistics",
+      "Health and social surveys",
+      "Environmental accounts"
+    ],
+    "zh": [
+      "人口普查与预测",
+      "消费者价格指数（CPI）与通货膨胀",
+      "劳动力调查与失业率",
+      "工业生产指数",
+      "GDP与国民账户",
+      "农业、渔业和林业统计",
+      "卫生与社会调查",
+      "环境账户"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds two European national statistics bureaus as part of the daily data source contribution.

## New Sources

### 🇪🇸 spain-ine — Instituto Nacional de Estadística (Spain)
- **Website:** https://www.ine.es/en/index.htm
- **Data Portal:** https://www.ine.es/en/prensa/prensa_encuesta_en.htm
- **API:** https://servicios.ine.es/wstempus/js/en/OPERACIONES_DISPONIBLES
- **Authority Level:** government
- **Domains:** economics, demographics, social, environment, labor
- **Coverage:** CPI, labor force survey, population census, GDP, industrial output

### 🇮🇹 italy-istat — Istituto Nazionale di Statistica (Italy)
- **Website:** https://www.istat.it/en/
- **Data Portal:** https://esploradati.istat.it/databrowser/
- **API:** https://sdmx.istat.it/SDMXWS/rest/
- **Authority Level:** government
- **Domains:** economics, demographics, social, environment, labor
- **Coverage:** National accounts, population census, CPI, labor market, regional statistics

## Validation
- ✅ `make validate` — all JSON schemas valid
- ✅ `make check-ids` — no duplicate IDs (158 total unique)
- ✅ `make check-domains` — domain consistency OK
- ✅ URLs verified accessible