### PR TITLE
feat: add spain-ine 🇪🇸 and italy-istat 🇮🇹 data sources

### DIFF
--- a/firstdata/sources/countries/europe/italy/italy-istat.json
+++ b/firstdata/sources/countries/europe/italy/italy-istat.json
@@ -1,0 +1,25 @@
+{
+  "id": "italy-istat",
+  "name": {
+    "en": "Italian National Institute of Statistics",
+    "zh": "意大利国家统计局"
+  },
+  "description": {
+    "en": "Italy's official statistical agency producing national accounts, population census, labor market, and regional statistics.",
+    "zh": "意大利官方统计机构，发布国民账户、人口普查、劳动力市场和区域统计数据。"
+  },
+  "website": "https://www.istat.it",
+  "data_url": "https://esploradati.istat.it/databrowser/",
+  "api_url": "https://esploradati.istat.it/SDMXWS/rest",
+  "data_content": {
+    "en": ["National accounts and GDP", "Population census", "Labor market statistics", "Consumer price index", "Regional economic indicators"],
+    "zh": ["国民账户与GDP", "人口普查", "劳动力市场统计", "消费者价格指数", "区域经济指标"]
+  },
+  "authority_level": "government",
+  "update_frequency": "monthly",
+  "coverage": "national",
+  "country_code": "IT",
+  "domains": ["economics", "demographics", "employment"],
+  "tags": ["italy", "statistics", "gdp", "census", "labor"],
+  "license": "open"
+}

--- a/firstdata/sources/countries/europe/spain/spain-ine.json
+++ b/firstdata/sources/countries/europe/spain/spain-ine.json
@@ -1,0 +1,25 @@
+{
+  "id": "spain-ine",
+  "name": {
+    "en": "National Statistics Institute of Spain",
+    "zh": "西班牙国家统计局"
+  },
+  "description": {
+    "en": "Spain's national statistical office producing official statistics on demographics, economy, labor market, and social conditions.",
+    "zh": "西班牙国家统计机构，发布人口、经济、劳动力市场和社会状况的官方统计数据。"
+  },
+  "website": "https://www.ine.es",
+  "data_url": "https://www.ine.es/dyngs/INEbase/listaoperaciones.htm",
+  "api_url": "https://servicios.ine.es/wstempus/js",
+  "data_content": {
+    "en": ["CPI and inflation", "Labor force survey", "Population census", "GDP and national accounts", "Industrial production index"],
+    "zh": ["消费者价格指数与通胀", "劳动力调查", "人口普查", "GDP与国民账户", "工业生产指数"]
+  },
+  "authority_level": "government",
+  "update_frequency": "monthly",
+  "coverage": "national",
+  "country_code": "ES",
+  "domains": ["economics", "demographics", "employment"],
+  "tags": ["spain", "statistics", "cpi", "labor", "gdp"],
+  "license": "open"
+}


### PR DESCRIPTION
Two European national statistics offices.

- **spain-ine** 🇪🇸 — National Statistics Institute of Spain (INE), CPI/GDP/labor/census
- **italy-istat** 🇮🇹 — Italian National Institute of Statistics (ISTAT), national accounts/census/regional stats

✅ Schema validation passed (254 unique IDs)
✅ spain-ine data_url fixed to working endpoint