### PR TITLE
feat: add Netherlands CBS and Sweden SCB statistics sources

### DIFF
--- a/firstdata/sources/countries/europe/nld/netherlands-cbs.json
+++ b/firstdata/sources/countries/europe/nld/netherlands-cbs.json
@@ -1,0 +1,45 @@
+{
+  "id": "netherlands-cbs",
+  "name": {
+    "en": "Statistics Netherlands (CBS)",
+    "zh": "荷兰统计局",
+    "native": "Centraal Bureau voor de Statistiek (CBS)"
+  },
+  "description": {
+    "en": "Statistics Netherlands (CBS) is the Dutch national statistical institute, providing high-quality statistical information about the Netherlands covering economy, population, health, education, environment, and society. CBS offers open data through its StatLine database and OData API.",
+    "zh": "荷兰统计局（CBS）是荷兰国家统计机构，提供涵盖经济、人口、健康、教育、环境和社会等领域的权威统计数据，通过StatLine数据库和OData API开放访问。"
+  },
+  "website": "https://www.cbs.nl",
+  "data_url": "https://opendata.cbs.nl",
+  "api_url": "https://opendata.cbs.nl/ODataApi/OData/",
+  "authority_level": "government",
+  "country": "NL",
+  "domains": ["economics", "demographics", "health", "education", "environment", "employment", "social"],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": ["netherlands", "holland", "cbs", "statistics netherlands", "dutch statistics", "statline", "odata", "荷兰", "荷兰统计局", "人口统计", "经济统计", "欧盟"],
+  "data_content": {
+    "en": [
+      "Population and demographics",
+      "GDP and national accounts",
+      "Employment and labor market",
+      "Health and healthcare statistics",
+      "Education and science",
+      "Environmental and energy statistics",
+      "Housing and construction",
+      "Trade and industry",
+      "Safety and crime statistics"
+    ],
+    "zh": [
+      "人口与人口统计",
+      "GDP与国民账户",
+      "就业与劳动力市场",
+      "卫生与医疗统计",
+      "教育与科学",
+      "环境与能源统计",
+      "住房与建筑",
+      "贸易与工业",
+      "安全与犯罪统计"
+    ]
+  }
+}

--- a/firstdata/sources/countries/europe/swe/sweden-scb.json
+++ b/firstdata/sources/countries/europe/swe/sweden-scb.json
@@ -1,0 +1,45 @@
+{
+  "id": "sweden-scb",
+  "name": {
+    "en": "Statistics Sweden (SCB)",
+    "zh": "瑞典统计局",
+    "native": "Statistiska centralbyrån (SCB)"
+  },
+  "description": {
+    "en": "Statistics Sweden (SCB) is Sweden's national statistical agency, responsible for developing, producing and disseminating statistics for decision-making, debate and research. SCB covers a broad range of topics including economy, population, environment, labor market, and public sector, with open data available via its Statistical Database API.",
+    "zh": "瑞典统计局（SCB）是瑞典国家统计机构，负责为决策、辩论和研究开发、生产和传播统计数据，涵盖经济、人口、环境、劳动力市场和公共部门等领域，通过统计数据库API提供开放数据。"
+  },
+  "website": "https://www.scb.se",
+  "data_url": "https://www.scb.se/en/finding-statistics/",
+  "api_url": "https://api.scb.se/OV0104/v1/doris/en/ssd",
+  "authority_level": "government",
+  "country": "SE",
+  "domains": ["economics", "demographics", "environment", "employment", "social", "education", "health"],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": ["sweden", "scb", "statistics sweden", "swedish statistics", "nordic", "skandinavien", "瑞典", "瑞典统计局", "北欧", "人口统计", "经济统计", "欧盟"],
+  "data_content": {
+    "en": [
+      "Population and demographic statistics",
+      "GDP and national accounts",
+      "Labor market and employment",
+      "Foreign trade statistics",
+      "Environmental and energy accounts",
+      "Education and research statistics",
+      "Health and medical statistics",
+      "Public finance and taxes",
+      "Regional and municipal statistics"
+    ],
+    "zh": [
+      "人口与人口统计",
+      "GDP与国民账户",
+      "劳动力市场与就业",
+      "对外贸易统计",
+      "环境与能源账户",
+      "教育与研究统计",
+      "卫生与医疗统计",
+      "公共财政与税收",
+      "区域与市级统计"
+    ]
+  }
+}


### PR DESCRIPTION
## New Data Sources

### 🇳🇱 Netherlands CBS (Centraal Bureau voor de Statistiek)
- **ID**: `netherlands-cbs`
- **Website**: https://www.cbs.nl
- **Data Portal**: https://opendata.cbs.nl
- **API**: https://opendata.cbs.nl/ODataApi/OData/
- **Domains**: economics, demographics, health, education, environment, employment, social
- **Coverage**: Population, GDP, employment, health, environment, housing, trade, safety

### 🇸🇪 Sweden SCB (Statistiska centralbyrån)
- **ID**: `sweden-scb`
- **Website**: https://www.scb.se
- **Data Portal**: https://www.scb.se/en/finding-statistics/
- **API**: https://api.scb.se/OV0104/v1/doris/en/ssd
- **Domains**: economics, demographics, environment, employment, social, education, health
- **Coverage**: Population, GDP, labor market, foreign trade, environment, education, public finance

## Validation
- ✅ `make validate` — schema compliant
- ✅ `make check-ids` — no duplicate IDs (158 total)
- ✅ `make check-domains` — domain consistency OK
- ✅ All URLs verified accessible