### PR TITLE
feat: add japan-esri, china-sac, china-csdc, cninfo data sources

### DIFF
--- a/firstdata/sources/china/china-csdc.json
+++ b/firstdata/sources/china/china-csdc.json
@@ -1,0 +1,25 @@
+{
+  "id": "china-csdc",
+  "name": {
+    "en": "China Securities Depository and Clearing Corporation",
+    "zh": "中国证券登记结算有限公司"
+  },
+  "description": {
+    "en": "China's central securities depository providing investor account statistics, settlement data, and securities registration services.",
+    "zh": "中国中央证券存管机构，提供投资者账户统计、清算结算数据和证券登记服务。"
+  },
+  "website": "https://www.chinaclear.cn",
+  "data_url": "https://www.chinaclear.cn/zdjs/tjyb/center_tjbg.shtml",
+  "api_url": null,
+  "data_content": {
+    "en": ["Investor account statistics", "Securities settlement data", "Market capitalization reports", "Bond custody data", "Monthly statistical bulletins"],
+    "zh": ["投资者账户统计", "证券结算数据", "市值报告", "债券托管数据", "月度统计公报"]
+  },
+  "authority_level": "other",
+  "update_frequency": "monthly",
+  "coverage": "national",
+  "country_code": "CN",
+  "domains": ["finance"],
+  "tags": ["securities", "clearing", "settlement", "investor", "china"],
+  "license": "open"
+}

--- a/firstdata/sources/china/china-sac.json
+++ b/firstdata/sources/china/china-sac.json
@@ -1,0 +1,25 @@
+{
+  "id": "china-sac",
+  "name": {
+    "en": "Securities Association of China",
+    "zh": "中国证券业协会"
+  },
+  "description": {
+    "en": "China's self-regulatory organization for the securities industry, publishing broker rankings, industry statistics, and member data.",
+    "zh": "中国证券行业自律组织，发布券商排名、行业统计和会员数据。"
+  },
+  "website": "https://www.sac.net.cn",
+  "data_url": "https://www.sac.net.cn/hysj/",
+  "api_url": null,
+  "data_content": {
+    "en": ["Securities broker rankings", "Industry revenue statistics", "Member firm data", "Practitioner registration", "Securities market overview"],
+    "zh": ["券商排名", "行业营收统计", "会员公司数据", "从业人员注册", "证券市场概览"]
+  },
+  "authority_level": "other",
+  "update_frequency": "quarterly",
+  "coverage": "national",
+  "country_code": "CN",
+  "domains": ["finance"],
+  "tags": ["securities", "broker", "china", "sac", "ranking"],
+  "license": "open"
+}

--- a/firstdata/sources/china/cninfo.json
+++ b/firstdata/sources/china/cninfo.json
@@ -1,0 +1,25 @@
+{
+  "id": "cninfo",
+  "name": {
+    "en": "CNINFO (Shenzhen Stock Exchange Information)",
+    "zh": "巨潮资讯网"
+  },
+  "description": {
+    "en": "CSRC-designated information disclosure platform for listed companies on Shenzhen and Shanghai exchanges, providing financial reports, announcements, and market data.",
+    "zh": "证监会指定信息披露平台，提供深沪上市公司财务报告、公告和市场数据。"
+  },
+  "website": "https://www.cninfo.com.cn",
+  "data_url": "https://www.cninfo.com.cn/new/commonUrl?url=disclosure/list/search",
+  "api_url": "https://www.cninfo.com.cn/new/hisAnnouncement/query",
+  "data_content": {
+    "en": ["Listed company financial reports", "Regulatory announcements", "IPO prospectuses", "Bond information", "Market statistics"],
+    "zh": ["上市公司财务报告", "监管公告", "IPO招股说明书", "债券信息", "市场统计"]
+  },
+  "authority_level": "government",
+  "update_frequency": "daily",
+  "coverage": "national",
+  "country_code": "CN",
+  "domains": ["finance"],
+  "tags": ["cninfo", "disclosure", "listed-company", "financial-report", "china"],
+  "license": "open"
+}

--- a/firstdata/sources/countries/asia/japan/japan-esri.json
+++ b/firstdata/sources/countries/asia/japan/japan-esri.json
@@ -1,0 +1,25 @@
+{
+  "id": "japan-esri",
+  "name": {
+    "en": "Economic and Social Research Institute, Cabinet Office of Japan",
+    "zh": "日本内阁府经济社会综合研究所"
+  },
+  "description": {
+    "en": "Japan's Cabinet Office institute responsible for national accounts (GDP/SNA), economic indicators, and business cycle research.",
+    "zh": "日本内阁府下属机构，负责国民账户（GDP/SNA）、经济指标和景气循环研究。"
+  },
+  "website": "https://www.esri.cao.go.jp",
+  "data_url": "https://www.esri.cao.go.jp/en/sna/menu.html",
+  "api_url": null,
+  "data_content": {
+    "en": ["GDP and System of National Accounts", "Quarterly GDP estimates", "Business cycle indicators", "Consumer confidence survey", "Economic outlook forecasts"],
+    "zh": ["GDP与国民经济计算体系", "季度GDP估算", "景气循环指标", "消费者信心调查", "经济展望预测"]
+  },
+  "authority_level": "government",
+  "update_frequency": "quarterly",
+  "coverage": "national",
+  "country_code": "JP",
+  "domains": ["economics"],
+  "tags": ["japan", "gdp", "sna", "national-accounts", "business-cycle"],
+  "license": "open"
+}


### PR DESCRIPTION
4 new data sources based on user demand analysis.

- **japan-esri** 🇯🇵 — Cabinet Office ESRI (GDP/SNA/business cycle)
- **china-sac** 🇨🇳 — Securities Association of China (broker rankings)
- **china-csdc** 🇨🇳 — China Securities Depository & Clearing (investor stats)
- **cninfo** 🇨🇳 — CSRC-designated disclosure platform (financial reports)

✅ Schema validated (260 unique IDs)
✅ All URLs use HTTPS