### PR TITLE
fix: standardize schema field names (country_code→country, coverage→geographic_scope)

### DIFF
--- a/firstdata/sources/china/china-csdc.json
+++ b/firstdata/sources/china/china-csdc.json
@@ -12,14 +12,33 @@
   "data_url": "https://www.chinaclear.cn/zdjs/tjyb/center_tjbg.shtml",
   "api_url": null,
   "data_content": {
-    "en": ["Investor account statistics", "Securities settlement data", "Market capitalization reports", "Bond custody data", "Monthly statistical bulletins"],
-    "zh": ["投资者账户统计", "证券结算数据", "市值报告", "债券托管数据", "月度统计公报"]
+    "en": [
+      "Investor account statistics",
+      "Securities settlement data",
+      "Market capitalization reports",
+      "Bond custody data",
+      "Monthly statistical bulletins"
+    ],
+    "zh": [
+      "投资者账户统计",
+      "证券结算数据",
+      "市值报告",
+      "债券托管数据",
+      "月度统计公报"
+    ]
   },
   "authority_level": "other",
   "update_frequency": "monthly",
-  "coverage": "national",
-  "country_code": "CN",
-  "domains": ["finance"],
-  "tags": ["securities", "clearing", "settlement", "investor", "china"],
-  "license": "open"
+  "domains": [
+    "finance"
+  ],
+  "tags": [
+    "securities",
+    "clearing",
+    "settlement",
+    "investor",
+    "china"
+  ],
+  "country": "CN",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/china/china-nea.json
+++ b/firstdata/sources/china/china-nea.json
@@ -25,8 +25,6 @@
   },
   "authority_level": "government",
   "update_frequency": "monthly",
-  "coverage": "national",
-  "country_code": "CN",
   "domains": [
     "energy"
   ],
@@ -37,5 +35,6 @@
     "power",
     "china"
   ],
-  "license": "open"
+  "country": "CN",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/china/china-sac.json
+++ b/firstdata/sources/china/china-sac.json
@@ -12,14 +12,33 @@
   "data_url": "https://www.sac.net.cn/hysj/",
   "api_url": null,
   "data_content": {
-    "en": ["Securities broker rankings", "Industry revenue statistics", "Member firm data", "Practitioner registration", "Securities market overview"],
-    "zh": ["券商排名", "行业营收统计", "会员公司数据", "从业人员注册", "证券市场概览"]
+    "en": [
+      "Securities broker rankings",
+      "Industry revenue statistics",
+      "Member firm data",
+      "Practitioner registration",
+      "Securities market overview"
+    ],
+    "zh": [
+      "券商排名",
+      "行业营收统计",
+      "会员公司数据",
+      "从业人员注册",
+      "证券市场概览"
+    ]
   },
   "authority_level": "other",
   "update_frequency": "quarterly",
-  "coverage": "national",
-  "country_code": "CN",
-  "domains": ["finance"],
-  "tags": ["securities", "broker", "china", "sac", "ranking"],
-  "license": "open"
+  "domains": [
+    "finance"
+  ],
+  "tags": [
+    "securities",
+    "broker",
+    "china",
+    "sac",
+    "ranking"
+  ],
+  "country": "CN",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/china/cninfo.json
+++ b/firstdata/sources/china/cninfo.json
@@ -12,14 +12,33 @@
   "data_url": "https://www.cninfo.com.cn/new/commonUrl?url=disclosure/list/search",
   "api_url": "https://www.cninfo.com.cn/new/hisAnnouncement/query",
   "data_content": {
-    "en": ["Listed company financial reports", "Regulatory announcements", "IPO prospectuses", "Bond information", "Market statistics"],
-    "zh": ["上市公司财务报告", "监管公告", "IPO招股说明书", "债券信息", "市场统计"]
+    "en": [
+      "Listed company financial reports",
+      "Regulatory announcements",
+      "IPO prospectuses",
+      "Bond information",
+      "Market statistics"
+    ],
+    "zh": [
+      "上市公司财务报告",
+      "监管公告",
+      "IPO招股说明书",
+      "债券信息",
+      "市场统计"
+    ]
   },
   "authority_level": "government",
   "update_frequency": "daily",
-  "coverage": "national",
-  "country_code": "CN",
-  "domains": ["finance"],
-  "tags": ["cninfo", "disclosure", "listed-company", "financial-report", "china"],
-  "license": "open"
+  "domains": [
+    "finance"
+  ],
+  "tags": [
+    "cninfo",
+    "disclosure",
+    "listed-company",
+    "financial-report",
+    "china"
+  ],
+  "country": "CN",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/countries/asia/dosm.json
+++ b/firstdata/sources/countries/asia/dosm.json
@@ -33,7 +33,6 @@
     "JSON",
     "Parquet"
   ],
-  "license": "Open Data",
   "contact": {
     "email": "info@dosm.gov.my",
     "phone": "+60 3-8885 7000"

--- a/firstdata/sources/countries/asia/japan/japan-esri.json
+++ b/firstdata/sources/countries/asia/japan/japan-esri.json
@@ -12,14 +12,33 @@
   "data_url": "https://www.esri.cao.go.jp/en/sna/menu.html",
   "api_url": null,
   "data_content": {
-    "en": ["GDP and System of National Accounts", "Quarterly GDP estimates", "Business cycle indicators", "Consumer confidence survey", "Economic outlook forecasts"],
-    "zh": ["GDP与国民经济计算体系", "季度GDP估算", "景气循环指标", "消费者信心调查", "经济展望预测"]
+    "en": [
+      "GDP and System of National Accounts",
+      "Quarterly GDP estimates",
+      "Business cycle indicators",
+      "Consumer confidence survey",
+      "Economic outlook forecasts"
+    ],
+    "zh": [
+      "GDP与国民经济计算体系",
+      "季度GDP估算",
+      "景气循环指标",
+      "消费者信心调查",
+      "经济展望预测"
+    ]
   },
   "authority_level": "government",
   "update_frequency": "quarterly",
-  "coverage": "national",
-  "country_code": "JP",
-  "domains": ["economics"],
-  "tags": ["japan", "gdp", "sna", "national-accounts", "business-cycle"],
-  "license": "open"
+  "domains": [
+    "economics"
+  ],
+  "tags": [
+    "japan",
+    "gdp",
+    "sna",
+    "national-accounts",
+    "business-cycle"
+  ],
+  "country": "JP",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/countries/asia/japan/japan-jma.json
+++ b/firstdata/sources/countries/asia/japan/japan-jma.json
@@ -26,8 +26,6 @@
   },
   "authority_level": "government",
   "update_frequency": "daily",
-  "coverage": "national",
-  "country_code": "JP",
   "domains": [
     "climate",
     "environment",
@@ -40,5 +38,6 @@
     "japan",
     "climate"
   ],
-  "license": "open"
+  "country": "JP",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/countries/europe/bank-of-england-statistics.json
+++ b/firstdata/sources/countries/europe/bank-of-england-statistics.json
@@ -78,14 +78,6 @@
     "en": "Varies by dataset: Daily (exchange rates, SONIA), Weekly (money markets), Monthly (lending, deposits), Quarterly (detailed breakdowns)",
     "zh": "因数据集而异：每日（汇率、SONIA）、每周（货币市场）、每月（信贷、存款）、每季度（详细分类）"
   },
-  "license": {
-    "type": "Open Government Licence",
-    "url": "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/",
-    "notes": {
-      "en": "Most data published under UK Open Government Licence v3.0, allowing free reuse with attribution. Some exchange rate data excluded due to third-party licensing.",
-      "zh": "大部分数据根据英国开放政府许可证 v3.0 发布，允许署名后自由使用。部分汇率数据因第三方许可而不包含在内。"
-    }
-  },
   "support": {
     "email": "BEEDSQueries@bankofengland.co.uk"
   },

--- a/firstdata/sources/countries/europe/italy/italy-istat.json
+++ b/firstdata/sources/countries/europe/italy/italy-istat.json
@@ -12,14 +12,35 @@
   "data_url": "https://esploradati.istat.it/databrowser/",
   "api_url": "https://esploradati.istat.it/SDMXWS/rest",
   "data_content": {
-    "en": ["National accounts and GDP", "Population census", "Labor market statistics", "Consumer price index", "Regional economic indicators"],
-    "zh": ["国民账户与GDP", "人口普查", "劳动力市场统计", "消费者价格指数", "区域经济指标"]
+    "en": [
+      "National accounts and GDP",
+      "Population census",
+      "Labor market statistics",
+      "Consumer price index",
+      "Regional economic indicators"
+    ],
+    "zh": [
+      "国民账户与GDP",
+      "人口普查",
+      "劳动力市场统计",
+      "消费者价格指数",
+      "区域经济指标"
+    ]
   },
   "authority_level": "government",
   "update_frequency": "monthly",
-  "coverage": "national",
-  "country_code": "IT",
-  "domains": ["economics", "demographics", "employment"],
-  "tags": ["italy", "statistics", "gdp", "census", "labor"],
-  "license": "open"
+  "domains": [
+    "economics",
+    "demographics",
+    "employment"
+  ],
+  "tags": [
+    "italy",
+    "statistics",
+    "gdp",
+    "census",
+    "labor"
+  ],
+  "country": "IT",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/countries/europe/netherlands/netherlands-cbs.json
+++ b/firstdata/sources/countries/europe/netherlands/netherlands-cbs.json
@@ -12,14 +12,43 @@
   "data_url": "https://opendata.cbs.nl/statline/",
   "api_url": "https://odata4.cbs.nl/CBS/Datasets",
   "data_content": {
-    "en": ["GDP and national accounts", "Population demographics", "International trade", "Labor market statistics", "Consumer price index", "Housing and construction", "Environment and energy"],
-    "zh": ["GDP与国民账户", "人口统计", "国际贸易", "劳动力市场", "消费者价格指数", "住房与建设", "环境与能源"]
+    "en": [
+      "GDP and national accounts",
+      "Population demographics",
+      "International trade",
+      "Labor market statistics",
+      "Consumer price index",
+      "Housing and construction",
+      "Environment and energy"
+    ],
+    "zh": [
+      "GDP与国民账户",
+      "人口统计",
+      "国际贸易",
+      "劳动力市场",
+      "消费者价格指数",
+      "住房与建设",
+      "环境与能源"
+    ]
   },
   "authority_level": "government",
   "update_frequency": "monthly",
-  "coverage": "national",
-  "country_code": "NL",
-  "domains": ["economics", "demographics", "trade", "employment", "environment", "housing", "energy"],
-  "tags": ["netherlands", "statistics", "cbs", "odata", "gdp"],
-  "license": "open"
+  "domains": [
+    "economics",
+    "demographics",
+    "trade",
+    "employment",
+    "environment",
+    "housing",
+    "energy"
+  ],
+  "tags": [
+    "netherlands",
+    "statistics",
+    "cbs",
+    "odata",
+    "gdp"
+  ],
+  "country": "NL",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/countries/europe/spain/spain-ine.json
+++ b/firstdata/sources/countries/europe/spain/spain-ine.json
@@ -12,14 +12,35 @@
   "data_url": "https://www.ine.es/dyngs/INEbase/listaoperaciones.htm",
   "api_url": "https://servicios.ine.es/wstempus/js",
   "data_content": {
-    "en": ["CPI and inflation", "Labor force survey", "Population census", "GDP and national accounts", "Industrial production index"],
-    "zh": ["消费者价格指数与通胀", "劳动力调查", "人口普查", "GDP与国民账户", "工业生产指数"]
+    "en": [
+      "CPI and inflation",
+      "Labor force survey",
+      "Population census",
+      "GDP and national accounts",
+      "Industrial production index"
+    ],
+    "zh": [
+      "消费者价格指数与通胀",
+      "劳动力调查",
+      "人口普查",
+      "GDP与国民账户",
+      "工业生产指数"
+    ]
   },
   "authority_level": "government",
   "update_frequency": "monthly",
-  "coverage": "national",
-  "country_code": "ES",
-  "domains": ["economics", "demographics", "employment"],
-  "tags": ["spain", "statistics", "cpi", "labor", "gdp"],
-  "license": "open"
+  "domains": [
+    "economics",
+    "demographics",
+    "employment"
+  ],
+  "tags": [
+    "spain",
+    "statistics",
+    "cpi",
+    "labor",
+    "gdp"
+  ],
+  "country": "ES",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/countries/europe/sweden/sweden-scb.json
+++ b/firstdata/sources/countries/europe/sweden/sweden-scb.json
@@ -12,14 +12,43 @@
   "data_url": "https://www.statistikdatabasen.scb.se",
   "api_url": "https://api.scb.se/OV0104/v1/doris/en",
   "data_content": {
-    "en": ["Population statistics", "GDP and economic indicators", "Labor force surveys", "Foreign trade", "Consumer price index", "Education statistics", "Environmental accounts"],
-    "zh": ["人口统计", "GDP与经济指标", "劳动力调查", "对外贸易", "消费者价格指数", "教育统计", "环境账户"]
+    "en": [
+      "Population statistics",
+      "GDP and economic indicators",
+      "Labor force surveys",
+      "Foreign trade",
+      "Consumer price index",
+      "Education statistics",
+      "Environmental accounts"
+    ],
+    "zh": [
+      "人口统计",
+      "GDP与经济指标",
+      "劳动力调查",
+      "对外贸易",
+      "消费者价格指数",
+      "教育统计",
+      "环境账户"
+    ]
   },
   "authority_level": "government",
   "update_frequency": "monthly",
-  "coverage": "national",
-  "country_code": "SE",
-  "domains": ["economics", "demographics", "trade", "employment", "education", "environment", "energy"],
-  "tags": ["sweden", "statistics", "scb", "gdp", "population"],
-  "license": "open"
+  "domains": [
+    "economics",
+    "demographics",
+    "trade",
+    "employment",
+    "education",
+    "environment",
+    "energy"
+  ],
+  "tags": [
+    "sweden",
+    "statistics",
+    "scb",
+    "gdp",
+    "population"
+  ],
+  "country": "SE",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/countries/europe/uk/uk-met-office.json
+++ b/firstdata/sources/countries/europe/uk/uk-met-office.json
@@ -25,8 +25,6 @@
   },
   "authority_level": "government",
   "update_frequency": "daily",
-  "coverage": "national",
-  "country_code": "GB",
   "domains": [
     "climate",
     "environment"
@@ -38,5 +36,6 @@
     "hadcrut",
     "uk"
   ],
-  "license": "open"
+  "country": "GB",
+  "geographic_scope": "national"
 }

--- a/firstdata/sources/international/climate/ecmwf.json
+++ b/firstdata/sources/international/climate/ecmwf.json
@@ -25,8 +25,6 @@
   },
   "authority_level": "international",
   "update_frequency": "daily",
-  "coverage": "global",
-  "country_code": null,
   "domains": [
     "climate",
     "environment"
@@ -38,5 +36,6 @@
     "forecast",
     "climate"
   ],
-  "license": "open"
+  "country": null,
+  "geographic_scope": "global"
 }

--- a/firstdata/sources/international/climate/ipcc.json
+++ b/firstdata/sources/international/climate/ipcc.json
@@ -25,8 +25,6 @@
   },
   "authority_level": "international",
   "update_frequency": "irregular",
-  "coverage": "global",
-  "country_code": null,
   "domains": [
     "climate",
     "environment"
@@ -38,5 +36,6 @@
     "temperature",
     "sea-level"
   ],
-  "license": "open"
+  "country": null,
+  "geographic_scope": "global"
 }

--- a/firstdata/sources/international/health/who-gho.json
+++ b/firstdata/sources/international/health/who-gho.json
@@ -28,8 +28,6 @@
   },
   "authority_level": "international",
   "update_frequency": "annual",
-  "coverage": "global",
-  "country_code": null,
   "domains": [
     "health"
   ],
@@ -40,5 +38,6 @@
     "disease",
     "immunization"
   ],
-  "license": "open"
+  "country": null,
+  "geographic_scope": "global"
 }

--- a/firstdata/sources/international/humanitarian/un-population.json
+++ b/firstdata/sources/international/humanitarian/un-population.json
@@ -26,8 +26,6 @@
   },
   "authority_level": "international",
   "update_frequency": "irregular",
-  "coverage": "global",
-  "country_code": null,
   "domains": [
     "demographics"
   ],
@@ -38,5 +36,6 @@
     "migration",
     "urbanization"
   ],
-  "license": "open"
+  "country": null,
+  "geographic_scope": "global"
 }

--- a/firstdata/sources/international/humanitarian/unhcr.json
+++ b/firstdata/sources/international/humanitarian/unhcr.json
@@ -26,8 +26,6 @@
   },
   "authority_level": "international",
   "update_frequency": "annual",
-  "coverage": "global",
-  "country_code": null,
   "domains": [
     "demographics",
     "humanitarian"
@@ -39,5 +37,6 @@
     "displacement",
     "humanitarian"
   ],
-  "license": "open"
+  "country": null,
+  "geographic_scope": "global"
 }

--- a/firstdata/sources/international/humanitarian/unicef.json
+++ b/firstdata/sources/international/humanitarian/unicef.json
@@ -27,8 +27,6 @@
   },
   "authority_level": "international",
   "update_frequency": "annual",
-  "coverage": "global",
-  "country_code": null,
   "domains": [
     "health",
     "demographics",
@@ -41,5 +39,6 @@
     "education",
     "development"
   ],
-  "license": "open"
+  "country": null,
+  "geographic_scope": "global"
 }


### PR DESCRIPTION
Fixes schema field naming inconsistency across 15 data sources added in PRs #51-#59.

Changes:
- `country_code` → `country` (schema-defined)
- `coverage` → `geographic_scope` (schema-defined)
- Removed non-schema `license` field

Credit: 明鉴 caught this in PR #59 review 👍