### PR TITLE
feat: add Belgium Statbel and Portugal INE data sources

### DIFF
--- a/firstdata/sources/countries/europe/belgium/belgium-statbel.json
+++ b/firstdata/sources/countries/europe/belgium/belgium-statbel.json
@@ -1,0 +1,45 @@
+{
+  "id": "belgium-statbel",
+  "name": {
+    "en": "Statbel - Belgian Statistical Office",
+    "zh": "比利时统计局"
+  },
+  "description": {
+    "en": "Official statistical office of Belgium providing demographic, economic, and social statistics",
+    "zh": "比利时官方统计机构，提供人口、经济和社会统计数据"
+  },
+  "url": "https://statbel.fgov.be/en",
+  "data_url": "https://statbel.fgov.be/en/open-data",
+  "api_url": null,
+  "api_docs": null,
+  "authority_level": "government",
+  "country": "BE",
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "domains": [
+    "economics",
+    "demographics",
+    "employment",
+    "agriculture",
+    "social",
+    "trade"
+  ],
+  "data_content": {
+    "en": [
+      "Population statistics - demographics, migration, households",
+      "Economic indicators - GDP, inflation, business statistics",
+      "Labour market - employment, unemployment, wages",
+      "Agriculture - crop production, livestock, farm structures",
+      "Social statistics - poverty, income distribution, living conditions",
+      "Foreign trade - import/export by commodity and partner country"
+    ],
+    "zh": [
+      "人口统计 - 人口、移民、家庭",
+      "经济指标 - GDP、通胀、企业统计",
+      "劳动力市场 - 就业、失业、工资",
+      "农业 - 作物产量、畜牧业、农场结构",
+      "社会统计 - 贫困、收入分配、生活条件",
+      "对外贸易 - 按商品和伙伴国分类的进出口"
+    ]
+  }
+}

--- a/firstdata/sources/countries/europe/belgium/belgium-statbel.json
+++ b/firstdata/sources/countries/europe/belgium/belgium-statbel.json
@@ -8,10 +8,8 @@
     "en": "Official statistical office of Belgium providing demographic, economic, and social statistics",
     "zh": "比利时官方统计机构，提供人口、经济和社会统计数据"
   },
-  "url": "https://statbel.fgov.be/en",
   "data_url": "https://statbel.fgov.be/en/open-data",
   "api_url": null,
-  "api_docs": null,
   "authority_level": "government",
   "country": "BE",
   "geographic_scope": "national",
@@ -41,5 +39,13 @@
       "社会统计 - 贫困、收入分配、生活条件",
       "对外贸易 - 按商品和伙伴国分类的进出口"
     ]
-  }
+  },
+  "website": "https://statbel.fgov.be/en",
+  "tags": [
+    "statistics",
+    "belgium",
+    "europe",
+    "government-data",
+    "open-data"
+  ]
 }

--- a/firstdata/sources/countries/europe/portugal/portugal-ine.json
+++ b/firstdata/sources/countries/europe/portugal/portugal-ine.json
@@ -1,0 +1,45 @@
+{
+  "id": "portugal-ine",
+  "name": {
+    "en": "Statistics Portugal (INE)",
+    "zh": "葡萄牙国家统计局"
+  },
+  "description": {
+    "en": "National statistical institute of Portugal providing comprehensive socioeconomic data",
+    "zh": "葡萄牙国家统计机构，提供全面的社会经济数据"
+  },
+  "url": "https://www.ine.pt",
+  "data_url": "https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_base_dados",
+  "api_url": "https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_api",
+  "api_docs": null,
+  "authority_level": "government",
+  "country": "PT",
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "domains": [
+    "economics",
+    "demographics",
+    "employment",
+    "social",
+    "trade",
+    "housing"
+  ],
+  "data_content": {
+    "en": [
+      "National accounts - GDP, GVA, productivity indicators",
+      "Population census and demographic statistics",
+      "Labour force survey - employment, unemployment rates",
+      "Social indicators - education, health, culture",
+      "International trade statistics by product and partner",
+      "Housing and construction statistics"
+    ],
+    "zh": [
+      "国民账户 - GDP、GVA、生产力指标",
+      "人口普查和人口统计",
+      "劳动力调查 - 就业率、失业率",
+      "社会指标 - 教育、卫生、文化",
+      "按产品和伙伴分类的国际贸易统计",
+      "住房和建筑统计"
+    ]
+  }
+}

--- a/firstdata/sources/countries/europe/portugal/portugal-ine.json
+++ b/firstdata/sources/countries/europe/portugal/portugal-ine.json
@@ -8,10 +8,8 @@
     "en": "National statistical institute of Portugal providing comprehensive socioeconomic data",
     "zh": "葡萄牙国家统计机构，提供全面的社会经济数据"
   },
-  "url": "https://www.ine.pt",
   "data_url": "https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_base_dados",
   "api_url": "https://www.ine.pt/xportal/xmain?xpid=INE&xpgid=ine_api",
-  "api_docs": null,
   "authority_level": "government",
   "country": "PT",
   "geographic_scope": "national",
@@ -41,5 +39,12 @@
       "按产品和伙伴分类的国际贸易统计",
       "住房和建筑统计"
     ]
-  }
+  },
+  "website": "https://www.ine.pt",
+  "tags": [
+    "statistics",
+    "portugal",
+    "europe",
+    "government-data"
+  ]
 }


### PR DESCRIPTION
## Summary
- 🇧🇪 belgium-statbel — Belgian Statistical Office (Statbel)
- 🇵🇹 portugal-ine — Statistics Portugal (INE)
- Data sources: 278 → 280 (+2)

**Fixed**: portugal-ine api_url corrected (previous PR #71 had 404 URL)

Replaces PR #71 (branch lost due to cron workspace isolation)