### PR TITLE
feat: add Czech Statistical Office (CZSO) and Ireland CSO

### DIFF
--- a/firstdata/sources/countries/europe/czechia/czechia-czso.json
+++ b/firstdata/sources/countries/europe/czechia/czechia-czso.json
@@ -1,0 +1,64 @@
+{
+  "id": "czechia-czso",
+  "name": {
+    "en": "Czech Statistical Office (CZSO)",
+    "zh": "捷克统计局"
+  },
+  "description": {
+    "en": "Official statistical office of the Czech Republic providing comprehensive demographic, economic, and social data since 1969",
+    "zh": "捷克共和国官方统计机构，自1969年起提供全面的人口、经济和社会数据"
+  },
+  "website": "https://csu.gov.cz",
+  "data_url": "https://vdb.czso.cz",
+  "api_url": "https://data.gov.cz",
+  "authority_level": "government",
+  "country": "CZ",
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "domains": [
+    "demographics",
+    "economics",
+    "employment",
+    "trade",
+    "agriculture",
+    "environment"
+  ],
+  "tags": [
+    "statistics",
+    "czechia",
+    "europe",
+    "government-data",
+    "open-data",
+    "捷克统计"
+  ],
+  "data_content": {
+    "en": [
+      "National accounts - GDP, GVA, productivity",
+      "Population census and demographic statistics",
+      "Labour force survey - employment, unemployment, wages",
+      "Consumer Price Index and inflation",
+      "Foreign trade statistics by product and partner",
+      "Agricultural census and crop statistics",
+      "Industrial production index",
+      "Regional statistics by NUTS classification",
+      "Environmental accounts and waste statistics",
+      "Tourism and hospitality statistics",
+      "Science, technology, and innovation indicators",
+      "Housing and construction statistics"
+    ],
+    "zh": [
+      "国民账户 - GDP、GVA、生产力",
+      "人口普查和人口统计",
+      "劳动力调查 - 就业、失业、工资",
+      "消费者价格指数和通胀",
+      "按产品和伙伴分类的对外贸易统计",
+      "农业普查和作物统计",
+      "工业生产指数",
+      "按NUTS分类的区域统计",
+      "环境账户和废物统计",
+      "旅游和酒店统计",
+      "科技创新指标",
+      "住房和建筑统计"
+    ]
+  }
+}

--- a/firstdata/sources/countries/europe/ireland/ireland-cso.json
+++ b/firstdata/sources/countries/europe/ireland/ireland-cso.json
@@ -1,0 +1,67 @@
+{
+  "id": "ireland-cso",
+  "name": {
+    "en": "Central Statistics Office (CSO)",
+    "zh": "爱尔兰中央统计局"
+  },
+  "description": {
+    "en": "Ireland's national statistical office established under the Statistics Act 1993, providing comprehensive socioeconomic data",
+    "zh": "依据1993年《统计法》成立的爱尔兰国家统计机构，提供全面的社会经济数据"
+  },
+  "website": "https://www.cso.ie",
+  "data_url": "https://data.cso.ie",
+  "api_url": "https://data.cso.ie",
+  "authority_level": "government",
+  "country": "IE",
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "domains": [
+    "demographics",
+    "economics",
+    "employment",
+    "trade",
+    "housing",
+    "health",
+    "crime-and-justice"
+  ],
+  "tags": [
+    "statistics",
+    "ireland",
+    "europe",
+    "government-data",
+    "json-stat",
+    "爱尔兰统计"
+  ],
+  "data_content": {
+    "en": [
+      "National accounts - GDP, GNI, Modified GNI",
+      "Population census and demographic projections",
+      "Labour force survey - employment, unemployment",
+      "Consumer Price Index and inflation",
+      "Foreign trade - merchandise and services",
+      "Housing and construction statistics",
+      "Health statistics and vital events",
+      "Crime and justice statistics",
+      "Tourism and transport data",
+      "Agriculture, forestry, and fishing",
+      "Environmental indicators",
+      "Business demographics and enterprise statistics",
+      "Education and training statistics"
+    ],
+    "zh": [
+      "国民账户 - GDP、GNI、修正GNI",
+      "人口普查和人口预测",
+      "劳动力调查 - 就业、失业",
+      "消费者价格指数和通胀",
+      "对外贸易 - 货物和服务",
+      "住房和建筑统计",
+      "卫生统计和生命事件",
+      "犯罪和司法统计",
+      "旅游和交通数据",
+      "农林渔业",
+      "环境指标",
+      "企业人口统计和企业统计",
+      "教育和培训统计"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- 🇨🇿 czechia-czso — Czech Statistical Office (Český statistický úřad)
- 🇮🇪 ireland-cso — Central Statistics Office of Ireland
- Data sources: 282 → 284 (+2)
- Fixed: ireland-cso domain `crime-and-justice` (was `crime and justice`)

Replaces PR #74 (branch lost, 6th cron branch loss)