### PR TITLE
fix: remove Authority badge from all READMEs

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -11,7 +11,6 @@ English | **[中文](README.md)** | **[日本語](README.ja.md)**
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Data Sources](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/MLT-OSS/FirstData/refs/heads/main/assets/badges/sources-count.json)](firstdata/indexes/statistics.json)
 [![Progress](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/MLT-OSS/FirstData/refs/heads/main/assets/badges/progress.json)](firstdata/indexes/statistics.json)
-[![Authority](https://img.shields.io/badge/Authority-Government%20%26%20International%20First-brightgreen.svg)](#)
 [![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](https://firstdata.deepminer.com.cn/)
 [![Skill](https://img.shields.io/badge/Skill-Agent%20First-blue.svg)](skills/firstdata/SKILL.md)
 [![ClawHub](https://img.shields.io/badge/ClawHub-firstdata-orange.svg)](https://clawhub.ai/ningzimu/firstdata)

--- a/README.ja.md
+++ b/README.ja.md
@@ -11,7 +11,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Data Sources](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/MLT-OSS/FirstData/refs/heads/main/assets/badges/sources-count.json)](firstdata/indexes/statistics.json)
 [![Progress](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/MLT-OSS/FirstData/refs/heads/main/assets/badges/progress.json)](firstdata/indexes/statistics.json)
-[![Authority](https://img.shields.io/badge/Authority-Government%20%26%20International%20First-brightgreen.svg)](#)
 [![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](https://firstdata.deepminer.com.cn/)
 [![Skill](https://img.shields.io/badge/Skill-Agent%20First-blue.svg)](skills/firstdata/SKILL.md)
 [![ClawHub](https://img.shields.io/badge/ClawHub-firstdata-orange.svg)](https://clawhub.ai/ningzimu/firstdata)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Data Sources](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/MLT-OSS/FirstData/refs/heads/main/assets/badges/sources-count.json)](firstdata/indexes/statistics.json)
 [![Progress](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/MLT-OSS/FirstData/refs/heads/main/assets/badges/progress.json)](firstdata/indexes/statistics.json)
-[![Authority](https://img.shields.io/badge/Authority-Government%20%26%20International%20First-brightgreen.svg)](#)
 [![MCP Server](https://img.shields.io/badge/MCP-AI%20Smart%20Search-purple.svg)](https://firstdata.deepminer.com.cn/)
 [![Skill](https://img.shields.io/badge/Skill-Agent%20First-blue.svg)](skills/firstdata/SKILL.md)
 [![ClawHub](https://img.shields.io/badge/ClawHub-firstdata-orange.svg)](https://clawhub.ai/ningzimu/firstdata)


### PR DESCRIPTION
## Summary
- Remove the Authority badge from README.md, README.en.md, and README.ja.md

## Test plan
- [x] Verify badge line is removed from all three README files
- [x] Remaining badges are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)