### PR TITLE
fix: brunei-deps data_url to edata-library

### DIFF
--- a/firstdata/sources/countries/asia/brunei/brunei-deps.json
+++ b/firstdata/sources/countries/asia/brunei/brunei-deps.json
@@ -9,7 +9,7 @@
     "zh": "文莱经济规划与统计局（DEPS）是文莱达鲁萨兰国的国家统计机构，隶属于首相府。负责编制和发布关于国民账户、人口、贸易、劳动力、物价和其他经济社会指标的官方统计数据。"
   },
   "website": "https://deps.mofe.gov.bn/",
-  "data_url": "https://deps.mofe.gov.bn/",
+  "data_url": "https://deps.mofe.gov.bn/edata-library/",
   "api_url": null,
   "authority_level": "government",
   "country": "BN",


### PR DESCRIPTION
Update brunei-deps data_url from main website to proper data portal (edata-library). Suggested by 明察.