### PR TITLE
feat: add Myanmar CSO data source

### DIFF
--- a/assets/badges/sources-count.json
+++ b/assets/badges/sources-count.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "sources",
-  "message": "310/1000+",
+  "message": "311/1000+",
   "color": "blue"
 }

--- a/firstdata/indexes/all-sources.json
+++ b/firstdata/indexes/all-sources.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "generated_at": "2026-03-27T02:25:29.779418+00:00",
-    "total_sources": 310,
+    "generated_at": "2026-03-27T20:24:07.746395+00:00",
+    "total_sources": 311,
     "version": "2.0",
     "schema_version": "v2.0.0"
   },
@@ -7380,6 +7380,65 @@
       "geographic_scope": "national",
       "has_api": true,
       "file_path": "countries/asia/malaysia/malaysia-dosm.json"
+    },
+    {
+      "id": "myanmar-cso",
+      "name": {
+        "en": "Central Statistical Organization (Myanmar)",
+        "zh": "缅甸中央统计局"
+      },
+      "description": {
+        "en": "Myanmar's principal government agency responsible for collecting, processing, and disseminating official statistics including GDP, population census, CPI, labor force surveys, foreign trade, industrial production, and agricultural statistics.",
+        "zh": "缅甸主要政府统计机构，负责收集、处理和发布官方统计数据，包括GDP、人口普查、消费者价格指数、劳动力调查、对外贸易、工业生产和农业统计。"
+      },
+      "website": "https://www.csostat.gov.mm",
+      "data_url": "https://www.csostat.gov.mm",
+      "api_url": null,
+      "country": "MM",
+      "geographic_scope": "national",
+      "authority_level": "government",
+      "domains": [
+        "economics",
+        "demographics",
+        "trade",
+        "agriculture"
+      ],
+      "update_frequency": "annual",
+      "data_content": {
+        "en": [
+          "GDP and national accounts",
+          "Population and housing census",
+          "Consumer price index (CPI)",
+          "Labor force survey",
+          "Foreign trade statistics",
+          "Industrial production index",
+          "Agricultural statistics",
+          "Social and vital statistics"
+        ],
+        "zh": [
+          "GDP与国民账户",
+          "人口与住房普查",
+          "消费者价格指数",
+          "劳动力调查",
+          "对外贸易统计",
+          "工业生产指数",
+          "农业统计",
+          "社会与人口动态统计"
+        ]
+      },
+      "tags": [
+        "myanmar",
+        "缅甸",
+        "statistics",
+        "统计局",
+        "ASEAN",
+        "东盟",
+        "GDP",
+        "census",
+        "CPI"
+      ],
+      "has_api": false,
+      "file_path": "countries/asia/myanmar/myanmar-cso.json"
     },
     {
       "id": "philippines-psa",

--- a/firstdata/indexes/by-authority.json
+++ b/firstdata/indexes/by-authority.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generated_at": "2026-03-27T02:25:29.779418+00:00",
-    "total_sources": 310,
+    "generated_at": "2026-03-27T20:24:07.746395+00:00",
+    "total_sources": 311,
     "authority_counts": {
       "research": 37,
       "international": 74,
-      "government": 165,
+      "government": 166,
       "other": 3,
       "market": 16,
       "commercial": 15
@@ -2315,6 +2315,18 @@
         "data_url": "https://open.dosm.gov.my/",
         "has_api": true,
         "file_path": "countries/asia/malaysia/malaysia-dosm.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "myanmar-cso",
+        "name": {
+          "en": "Central Statistical Organization (Myanmar)",
+          "zh": "缅甸中央统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.csostat.gov.mm",
+        "has_api": false,
+        "file_path": "countries/asia/myanmar/myanmar-cso.json",
         "geographic_scope": "national"
       },
       {

--- a/firstdata/indexes/by-domain.json
+++ b/firstdata/indexes/by-domain.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "generated_at": "2026-03-27T02:25:29.779418+00:00",
+    "generated_at": "2026-03-27T20:24:07.746395+00:00",
     "total_domains": 711,
-    "total_sources": 310,
+    "total_sources": 311,
     "version": "2.0"
   },
   "domains": {
@@ -373,6 +373,18 @@
         "data_url": "https://kosis.kr/eng/",
         "has_api": true,
         "file_path": "countries/asia/kostat.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "myanmar-cso",
+        "name": {
+          "en": "Central Statistical Organization (Myanmar)",
+          "zh": "缅甸中央统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.csostat.gov.mm",
+        "has_api": false,
+        "file_path": "countries/asia/myanmar/myanmar-cso.json",
         "geographic_scope": "national"
       },
       {
@@ -4539,6 +4551,18 @@
         "geographic_scope": "national"
       },
       {
+        "id": "myanmar-cso",
+        "name": {
+          "en": "Central Statistical Organization (Myanmar)",
+          "zh": "缅甸中央统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.csostat.gov.mm",
+        "has_api": false,
+        "file_path": "countries/asia/myanmar/myanmar-cso.json",
+        "geographic_scope": "national"
+      },
+      {
         "id": "philippines-psa",
         "name": {
           "en": "Philippine Statistics Authority",
@@ -6644,6 +6668,18 @@
         "data_url": "https://open.dosm.gov.my/",
         "has_api": true,
         "file_path": "countries/asia/malaysia/malaysia-dosm.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "myanmar-cso",
+        "name": {
+          "en": "Central Statistical Organization (Myanmar)",
+          "zh": "缅甸中央统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.csostat.gov.mm",
+        "has_api": false,
+        "file_path": "countries/asia/myanmar/myanmar-cso.json",
         "geographic_scope": "national"
       },
       {
@@ -22443,6 +22479,18 @@
         "data_url": "https://kosis.kr/eng/",
         "has_api": true,
         "file_path": "countries/asia/kostat.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "myanmar-cso",
+        "name": {
+          "en": "Central Statistical Organization (Myanmar)",
+          "zh": "缅甸中央统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.csostat.gov.mm",
+        "has_api": false,
+        "file_path": "countries/asia/myanmar/myanmar-cso.json",
         "geographic_scope": "national"
       },
       {

--- a/firstdata/indexes/by-region.json
+++ b/firstdata/indexes/by-region.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "generated_at": "2026-03-27T02:25:29.779418+00:00",
-    "total_regions": 53,
-    "total_sources": 310,
+    "generated_at": "2026-03-27T20:24:07.746395+00:00",
+    "total_regions": 54,
+    "total_sources": 311,
     "version": "2.0"
   },
   "regions": {
@@ -1681,6 +1681,20 @@
         "data_url": "https://laosis.lsb.gov.la/",
         "has_api": false,
         "file_path": "countries/asia/laos/laos-lsb.json",
+        "geographic_scope": "national"
+      }
+    ],
+    "MM": [
+      {
+        "id": "myanmar-cso",
+        "name": {
+          "en": "Central Statistical Organization (Myanmar)",
+          "zh": "缅甸中央统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.csostat.gov.mm",
+        "has_api": false,
+        "file_path": "countries/asia/myanmar/myanmar-cso.json",
         "geographic_scope": "national"
       }
     ],

--- a/firstdata/indexes/statistics.json
+++ b/firstdata/indexes/statistics.json
@@ -1,24 +1,24 @@
 {
   "metadata": {
-    "generated_at": "2026-03-27T02:25:29.779418+00:00",
+    "generated_at": "2026-03-27T20:24:07.746395+00:00",
     "version": "2.0"
   },
   "overview": {
-    "total_sources": 310,
+    "total_sources": 311,
     "sources_with_api": 150,
     "last_updated": "2026-03-27"
   },
   "by_authority_level": {
     "research": 37,
     "international": 74,
-    "government": 165,
+    "government": 166,
     "other": 3,
     "market": 16,
     "commercial": 15
   },
   "by_geographic_scope": {
     "global": 100,
-    "national": 184,
+    "national": 185,
     "regional": 26
   },
   "by_update_frequency": {
@@ -27,16 +27,16 @@
     "weekly": 9,
     "quarterly": 33,
     "monthly": 97,
-    "annual": 60,
+    "annual": 61,
     "real-time": 11
   },
   "by_domain": {
-    "economics": 122,
-    "trade": 72,
-    "demographics": 69,
+    "economics": 123,
+    "trade": 73,
+    "demographics": 70,
     "environment": 54,
     "finance": 50,
-    "agriculture": 46,
+    "agriculture": 47,
     "social": 45,
     "health": 42,
     "employment": 40,

--- a/firstdata/sources/countries/asia/myanmar/myanmar-cso.json
+++ b/firstdata/sources/countries/asia/myanmar/myanmar-cso.json
@@ -1,0 +1,57 @@
+{
+  "id": "myanmar-cso",
+  "name": {
+    "en": "Central Statistical Organization (Myanmar)",
+    "zh": "缅甸中央统计局"
+  },
+  "description": {
+    "en": "Myanmar's principal government agency responsible for collecting, processing, and disseminating official statistics including GDP, population census, CPI, labor force surveys, foreign trade, industrial production, and agricultural statistics.",
+    "zh": "缅甸主要政府统计机构，负责收集、处理和发布官方统计数据，包括GDP、人口普查、消费者价格指数、劳动力调查、对外贸易、工业生产和农业统计。"
+  },
+  "website": "https://www.csostat.gov.mm",
+  "data_url": "https://www.csostat.gov.mm",
+  "api_url": null,
+  "country": "MM",
+  "geographic_scope": "national",
+  "authority_level": "government",
+  "domains": [
+    "economics",
+    "demographics",
+    "trade",
+    "agriculture"
+  ],
+  "update_frequency": "annual",
+  "data_content": {
+    "en": [
+      "GDP and national accounts",
+      "Population and housing census",
+      "Consumer price index (CPI)",
+      "Labor force survey",
+      "Foreign trade statistics",
+      "Industrial production index",
+      "Agricultural statistics",
+      "Social and vital statistics"
+    ],
+    "zh": [
+      "GDP与国民账户",
+      "人口与住房普查",
+      "消费者价格指数",
+      "劳动力调查",
+      "对外贸易统计",
+      "工业生产指数",
+      "农业统计",
+      "社会与人口动态统计"
+    ]
+  },
+  "tags": [
+    "myanmar",
+    "缅甸",
+    "statistics",
+    "统计局",
+    "ASEAN",
+    "东盟",
+    "GDP",
+    "census",
+    "CPI"
+  ]
+}


### PR DESCRIPTION
Add Central Statistical Organization (Myanmar) 🇲🇲

ASEAN coverage: 10/10 complete!

- ID: myanmar-cso
- Website: https://www.csostat.gov.mm (200 ✅)
- No native field ✅
- check-candidate.sh verified ✅
- 311 IDs unique ✅