### PR TITLE
feat: add Kenya KNBS and Ghana GSS data sources

### DIFF
--- a/assets/badges/progress.json
+++ b/assets/badges/progress.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "progress",
-  "message": "31%",
+  "message": "32%",
   "color": "yellow"
 }

--- a/assets/badges/sources-count.json
+++ b/assets/badges/sources-count.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
   "label": "sources",
-  "message": "313/1000+",
+  "message": "315/1000+",
   "color": "blue"
 }

--- a/firstdata/indexes/all-sources.json
+++ b/firstdata/indexes/all-sources.json
@@ -1,7 +1,7 @@
 {
   "metadata": {
-    "generated_at": "2026-03-29T17:49:24.175388+00:00",
-    "total_sources": 313,
+    "generated_at": "2026-03-30T01:14:48.451037+00:00",
+    "total_sources": 315,
     "version": "2.0",
     "schema_version": "v2.0.0"
   },
@@ -5605,6 +5605,125 @@
       "geographic_scope": "national",
       "has_api": false,
       "file_path": "countries/africa/egypt/egypt-capmas.json"
+    },
+    {
+      "id": "ghana-gss",
+      "name": {
+        "en": "Ghana Statistical Service",
+        "zh": "加纳统计局"
+      },
+      "description": {
+        "en": "Ghana's official statistical agency responsible for producing population census, GDP, CPI, labor force surveys, trade statistics, and other socioeconomic indicators.",
+        "zh": "加纳官方统计机构，负责发布人口普查、GDP、消费者价格指数、劳动力调查、贸易统计和其他社会经济指标。"
+      },
+      "website": "https://statsghana.gov.gh",
+      "data_url": "https://statsghana.gov.gh/dissemination.php",
+      "api_url": null,
+      "country": "GH",
+      "geographic_scope": "national",
+      "authority_level": "government",
+      "domains": [
+        "economics",
+        "demographics",
+        "trade",
+        "agriculture"
+      ],
+      "update_frequency": "annual",
+      "data_content": {
+        "en": [
+          "Population and housing census",
+          "GDP and national accounts",
+          "Consumer price index (CPI)",
+          "Labor force survey",
+          "Foreign trade statistics",
+          "Agricultural census",
+          "Living standards survey",
+          "Industrial statistics"
+        ],
+        "zh": [
+          "人口与住房普查",
+          "GDP与国民账户",
+          "消费者价格指数",
+          "劳动力调查",
+          "对外贸易统计",
+          "农业普查",
+          "生活水平调查",
+          "工业统计"
+        ]
+      },
+      "tags": [
+        "ghana",
+        "加纳",
+        "statistics",
+        "统计局",
+        "Africa",
+        "非洲",
+        "GDP",
+        "census",
+        "CPI"
+      ],
+      "has_api": false,
+      "file_path": "countries/africa/ghana/ghana-gss.json"
+    },
+    {
+      "id": "kenya-knbs",
+      "name": {
+        "en": "Kenya National Bureau of Statistics",
+        "zh": "肯尼亚国家统计局"
+      },
+      "description": {
+        "en": "Kenya's principal agency for collecting, analyzing, and disseminating statistical data including population census, economic surveys, CPI, GDP, labor force, trade, and household surveys.",
+        "zh": "肯尼亚负责收集、分析和发布统计数据的主要机构，包括人口普查、经济调查、消费者价格指数、GDP、劳动力、贸易和住户调查。"
+      },
+      "website": "https://www.knbs.or.ke",
+      "data_url": "https://www.knbs.or.ke/publications/",
+      "api_url": null,
+      "country": "KE",
+      "geographic_scope": "national",
+      "authority_level": "government",
+      "domains": [
+        "economics",
+        "demographics",
+        "trade",
+        "agriculture",
+        "health"
+      ],
+      "update_frequency": "annual",
+      "data_content": {
+        "en": [
+          "Population and housing census",
+          "Economic survey",
+          "Consumer price index (CPI)",
+          "GDP and national accounts",
+          "Labor force statistics",
+          "Foreign trade statistics",
+          "Agricultural production",
+          "Health and demographic indicators"
+        ],
+        "zh": [
+          "人口与住房普查",
+          "经济调查",
+          "消费者价格指数",
+          "GDP与国民账户",
+          "劳动力统计",
+          "对外贸易统计",
+          "农业生产",
+          "健康与人口指标"
+        ]
+      },
+      "tags": [
+        "kenya",
+        "肯尼亚",
+        "statistics",
+        "统计局",
+        "Africa",
+        "非洲",
+        "GDP",
+        "census",
+        "CPI"
+      ],
+      "has_api": false,
+      "file_path": "countries/africa/kenya/kenya-knbs.json"
     },
     {
       "id": "nigeria-nbs",

--- a/firstdata/indexes/by-authority.json
+++ b/firstdata/indexes/by-authority.json
@@ -1,11 +1,11 @@
 {
   "metadata": {
-    "generated_at": "2026-03-29T17:49:24.175388+00:00",
-    "total_sources": 313,
+    "generated_at": "2026-03-30T01:14:48.451037+00:00",
+    "total_sources": 315,
     "authority_counts": {
       "research": 37,
       "international": 74,
-      "government": 168,
+      "government": 170,
       "other": 3,
       "market": 16,
       "commercial": 15
@@ -2005,6 +2005,30 @@
         "data_url": "https://www.capmas.gov.eg/Pages/Publications.aspx",
         "has_api": false,
         "file_path": "countries/africa/egypt/egypt-capmas.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "ghana-gss",
+        "name": {
+          "en": "Ghana Statistical Service",
+          "zh": "加纳统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://statsghana.gov.gh/dissemination.php",
+        "has_api": false,
+        "file_path": "countries/africa/ghana/ghana-gss.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "kenya-knbs",
+        "name": {
+          "en": "Kenya National Bureau of Statistics",
+          "zh": "肯尼亚国家统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.knbs.or.ke/publications/",
+        "has_api": false,
+        "file_path": "countries/africa/kenya/kenya-knbs.json",
         "geographic_scope": "national"
       },
       {

--- a/firstdata/indexes/by-domain.json
+++ b/firstdata/indexes/by-domain.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "generated_at": "2026-03-29T17:49:24.175388+00:00",
+    "generated_at": "2026-03-30T01:14:48.451037+00:00",
     "total_domains": 703,
-    "total_sources": 313,
+    "total_sources": 315,
     "version": "2.0"
   },
   "domains": {
@@ -310,6 +310,30 @@
         "data_url": "https://std.samr.gov.cn/",
         "has_api": false,
         "file_path": "china/technology/standards/china-sac-standards.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "ghana-gss",
+        "name": {
+          "en": "Ghana Statistical Service",
+          "zh": "加纳统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://statsghana.gov.gh/dissemination.php",
+        "has_api": false,
+        "file_path": "countries/africa/ghana/ghana-gss.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "kenya-knbs",
+        "name": {
+          "en": "Kenya National Bureau of Statistics",
+          "zh": "肯尼亚国家统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.knbs.or.ke/publications/",
+        "has_api": false,
+        "file_path": "countries/africa/kenya/kenya-knbs.json",
         "geographic_scope": "national"
       },
       {
@@ -4435,6 +4459,30 @@
         "geographic_scope": "national"
       },
       {
+        "id": "ghana-gss",
+        "name": {
+          "en": "Ghana Statistical Service",
+          "zh": "加纳统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://statsghana.gov.gh/dissemination.php",
+        "has_api": false,
+        "file_path": "countries/africa/ghana/ghana-gss.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "kenya-knbs",
+        "name": {
+          "en": "Kenya National Bureau of Statistics",
+          "zh": "肯尼亚国家统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.knbs.or.ke/publications/",
+        "has_api": false,
+        "file_path": "countries/africa/kenya/kenya-knbs.json",
+        "geographic_scope": "national"
+      },
+      {
         "id": "nigeria-nbs",
         "name": {
           "en": "National Bureau of Statistics Nigeria (NBS)",
@@ -6498,6 +6546,30 @@
         "data_url": "https://www.capmas.gov.eg/Pages/Publications.aspx",
         "has_api": false,
         "file_path": "countries/africa/egypt/egypt-capmas.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "ghana-gss",
+        "name": {
+          "en": "Ghana Statistical Service",
+          "zh": "加纳统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://statsghana.gov.gh/dissemination.php",
+        "has_api": false,
+        "file_path": "countries/africa/ghana/ghana-gss.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "kenya-knbs",
+        "name": {
+          "en": "Kenya National Bureau of Statistics",
+          "zh": "肯尼亚国家统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.knbs.or.ke/publications/",
+        "has_api": false,
+        "file_path": "countries/africa/kenya/kenya-knbs.json",
         "geographic_scope": "national"
       },
       {
@@ -13167,6 +13239,18 @@
         "data_url": "https://www.nhc.gov.cn/mohwsbwstjxxzx/s7967/new_list.shtml",
         "has_api": false,
         "file_path": "china/health/china-nhc.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "kenya-knbs",
+        "name": {
+          "en": "Kenya National Bureau of Statistics",
+          "zh": "肯尼亚国家统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.knbs.or.ke/publications/",
+        "has_api": false,
+        "file_path": "countries/africa/kenya/kenya-knbs.json",
         "geographic_scope": "national"
       },
       {
@@ -22542,6 +22626,30 @@
         "data_url": "https://www.safe.gov.cn/safe/tjsj1/index.html",
         "has_api": false,
         "file_path": "china/finance/forex/china-safe.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "ghana-gss",
+        "name": {
+          "en": "Ghana Statistical Service",
+          "zh": "加纳统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://statsghana.gov.gh/dissemination.php",
+        "has_api": false,
+        "file_path": "countries/africa/ghana/ghana-gss.json",
+        "geographic_scope": "national"
+      },
+      {
+        "id": "kenya-knbs",
+        "name": {
+          "en": "Kenya National Bureau of Statistics",
+          "zh": "肯尼亚国家统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.knbs.or.ke/publications/",
+        "has_api": false,
+        "file_path": "countries/africa/kenya/kenya-knbs.json",
         "geographic_scope": "national"
       },
       {

--- a/firstdata/indexes/by-region.json
+++ b/firstdata/indexes/by-region.json
@@ -1,8 +1,8 @@
 {
   "metadata": {
-    "generated_at": "2026-03-29T17:49:24.175388+00:00",
-    "total_regions": 56,
-    "total_sources": 313,
+    "generated_at": "2026-03-30T01:14:48.451037+00:00",
+    "total_regions": 58,
+    "total_sources": 315,
     "version": "2.0"
   },
   "regions": {
@@ -1339,6 +1339,20 @@
         "geographic_scope": "national"
       }
     ],
+    "GH": [
+      {
+        "id": "ghana-gss",
+        "name": {
+          "en": "Ghana Statistical Service",
+          "zh": "加纳统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://statsghana.gov.gh/dissemination.php",
+        "has_api": false,
+        "file_path": "countries/africa/ghana/ghana-gss.json",
+        "geographic_scope": "national"
+      }
+    ],
     "GR": [
       {
         "id": "greece-elstat",
@@ -1615,6 +1629,20 @@
         "data_url": "https://www.customs.go.jp/toukei/info/index_e.htm",
         "has_api": true,
         "file_path": "japan/trade/japan-customs.json",
+        "geographic_scope": "national"
+      }
+    ],
+    "KE": [
+      {
+        "id": "kenya-knbs",
+        "name": {
+          "en": "Kenya National Bureau of Statistics",
+          "zh": "肯尼亚国家统计局"
+        },
+        "authority_level": "government",
+        "data_url": "https://www.knbs.or.ke/publications/",
+        "has_api": false,
+        "file_path": "countries/africa/kenya/kenya-knbs.json",
         "geographic_scope": "national"
       }
     ],

--- a/firstdata/indexes/statistics.json
+++ b/firstdata/indexes/statistics.json
@@ -1,24 +1,24 @@
 {
   "metadata": {
-    "generated_at": "2026-03-29T17:49:24.175388+00:00",
+    "generated_at": "2026-03-30T01:14:48.451037+00:00",
     "version": "2.0"
   },
   "overview": {
-    "total_sources": 313,
+    "total_sources": 315,
     "sources_with_api": 150,
-    "last_updated": "2026-03-29"
+    "last_updated": "2026-03-30"
   },
   "by_authority_level": {
     "research": 37,
     "international": 74,
-    "government": 168,
+    "government": 170,
     "other": 3,
     "market": 16,
     "commercial": 15
   },
   "by_geographic_scope": {
     "global": 100,
-    "national": 187,
+    "national": 189,
     "regional": 26
   },
   "by_update_frequency": {
@@ -27,18 +27,18 @@
     "weekly": 9,
     "quarterly": 33,
     "monthly": 99,
-    "annual": 61,
+    "annual": 63,
     "real-time": 11
   },
   "by_domain": {
-    "economics": 125,
-    "trade": 75,
-    "demographics": 72,
+    "economics": 127,
+    "trade": 77,
+    "demographics": 74,
     "environment": 55,
+    "agriculture": 51,
     "finance": 50,
-    "agriculture": 49,
     "social": 47,
-    "health": 42,
+    "health": 43,
     "employment": 42,
     "education": 40,
     "energy": 26,

--- a/firstdata/sources/countries/africa/ghana/ghana-gss.json
+++ b/firstdata/sources/countries/africa/ghana/ghana-gss.json
@@ -9,7 +9,7 @@
     "zh": "加纳官方统计机构，负责发布人口普查、GDP、消费者价格指数、劳动力调查、贸易统计和其他社会经济指标。"
   },
   "website": "https://statsghana.gov.gh",
-  "data_url": "https://statsghana.gov.gh/dissemination.php",
+  "data_url": "https://statsghana.gov.gh/data-statistics/economic-statistics",
   "api_url": null,
   "country": "GH",
   "geographic_scope": "national",

--- a/firstdata/sources/countries/africa/ghana/ghana-gss.json
+++ b/firstdata/sources/countries/africa/ghana/ghana-gss.json
@@ -1,0 +1,57 @@
+{
+  "id": "ghana-gss",
+  "name": {
+    "en": "Ghana Statistical Service",
+    "zh": "加纳统计局"
+  },
+  "description": {
+    "en": "Ghana's official statistical agency responsible for producing population census, GDP, CPI, labor force surveys, trade statistics, and other socioeconomic indicators.",
+    "zh": "加纳官方统计机构，负责发布人口普查、GDP、消费者价格指数、劳动力调查、贸易统计和其他社会经济指标。"
+  },
+  "website": "https://statsghana.gov.gh",
+  "data_url": "https://statsghana.gov.gh/dissemination.php",
+  "api_url": null,
+  "country": "GH",
+  "geographic_scope": "national",
+  "authority_level": "government",
+  "domains": [
+    "economics",
+    "demographics",
+    "trade",
+    "agriculture"
+  ],
+  "update_frequency": "annual",
+  "data_content": {
+    "en": [
+      "Population and housing census",
+      "GDP and national accounts",
+      "Consumer price index (CPI)",
+      "Labor force survey",
+      "Foreign trade statistics",
+      "Agricultural census",
+      "Living standards survey",
+      "Industrial statistics"
+    ],
+    "zh": [
+      "人口与住房普查",
+      "GDP与国民账户",
+      "消费者价格指数",
+      "劳动力调查",
+      "对外贸易统计",
+      "农业普查",
+      "生活水平调查",
+      "工业统计"
+    ]
+  },
+  "tags": [
+    "ghana",
+    "加纳",
+    "statistics",
+    "统计局",
+    "Africa",
+    "非洲",
+    "GDP",
+    "census",
+    "CPI"
+  ]
+}

--- a/firstdata/sources/countries/africa/kenya/kenya-knbs.json
+++ b/firstdata/sources/countries/africa/kenya/kenya-knbs.json
@@ -1,0 +1,58 @@
+{
+  "id": "kenya-knbs",
+  "name": {
+    "en": "Kenya National Bureau of Statistics",
+    "zh": "肯尼亚国家统计局"
+  },
+  "description": {
+    "en": "Kenya's principal agency for collecting, analyzing, and disseminating statistical data including population census, economic surveys, CPI, GDP, labor force, trade, and household surveys.",
+    "zh": "肯尼亚负责收集、分析和发布统计数据的主要机构，包括人口普查、经济调查、消费者价格指数、GDP、劳动力、贸易和住户调查。"
+  },
+  "website": "https://www.knbs.or.ke",
+  "data_url": "https://www.knbs.or.ke/publications/",
+  "api_url": null,
+  "country": "KE",
+  "geographic_scope": "national",
+  "authority_level": "government",
+  "domains": [
+    "economics",
+    "demographics",
+    "trade",
+    "agriculture",
+    "health"
+  ],
+  "update_frequency": "annual",
+  "data_content": {
+    "en": [
+      "Population and housing census",
+      "Economic survey",
+      "Consumer price index (CPI)",
+      "GDP and national accounts",
+      "Labor force statistics",
+      "Foreign trade statistics",
+      "Agricultural production",
+      "Health and demographic indicators"
+    ],
+    "zh": [
+      "人口与住房普查",
+      "经济调查",
+      "消费者价格指数",
+      "GDP与国民账户",
+      "劳动力统计",
+      "对外贸易统计",
+      "农业生产",
+      "健康与人口指标"
+    ]
+  },
+  "tags": [
+    "kenya",
+    "肯尼亚",
+    "statistics",
+    "统计局",
+    "Africa",
+    "非洲",
+    "GDP",
+    "census",
+    "CPI"
+  ]
+}


### PR DESCRIPTION
🇰🇪 Kenya National Bureau of Statistics + 🇬🇭 Ghana Statistical Service

Africa coverage: 5 countries (🇿🇦 🇪🇬 🇳🇬 🇰🇪 🇬🇭)

- kenya-knbs: https://www.knbs.or.ke ✅
- ghana-gss: https://statsghana.gov.gh ✅
- check-candidate.sh verified ✅
- 315 IDs unique ✅
- No native field ✅