### PR TITLE
feat: add 5 Chinese government data sources (AM batch, 2026-04-06)

### DIFF
--- a/firstdata/sources/china/governance/china-nrta.json
+++ b/firstdata/sources/china/governance/china-nrta.json
@@ -1,0 +1,74 @@
+{
+  "id": "china-nrta",
+  "name": {
+    "en": "National Radio and Television Administration of China",
+    "zh": "国家广播电视总局"
+  },
+  "description": {
+    "en": "The National Radio and Television Administration (NRTA) is China's primary government authority responsible for regulating the radio and television broadcasting industry, including content supervision, licensing, technical standards, and industry development. Established in 2018 by merging the former State Administration of Press, Publication, Radio, Film and Television (SAPPRFT) functions, NRTA publishes annual statistical bulletins on China's broadcasting sector covering the number of licensed radio and TV stations, broadcast hours, cable and satellite subscriber data, program production volume, internet audio-visual service platforms, and smart TV penetration rates. Its data is essential for analyzing China's media landscape, digital broadcasting transition, and content regulation environment.",
+    "zh": "国家广播电视总局是中国广播电视行业的主管部门，负责广播电视内容监管、行业许可、技术标准制定和产业发展规划。2018年由原国家新闻出版广播电影电视总局相关职能重组而来。广电总局每年发布全国广播电视统计公报，涵盖持证广播电视播出机构数量、播出时长、有线及卫星用户数据、节目制作播出量、互联网视听服务平台许可情况及智能电视普及率等核心数据，是研究中国媒体格局、数字广播转型和内容监管环境的重要参考。"
+  },
+  "website": "https://www.nrta.gov.cn/",
+  "data_url": "https://www.nrta.gov.cn/col/col2040/index.html",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "media",
+    "governance",
+    "technology"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "广播电视总局",
+    "NRTA",
+    "National Radio Television Administration",
+    "广播电视",
+    "broadcasting",
+    "电视台",
+    "television station",
+    "广播电台",
+    "radio station",
+    "有线电视",
+    "cable TV",
+    "卫星电视",
+    "satellite TV",
+    "互联网视听",
+    "internet audiovisual",
+    "流媒体",
+    "streaming",
+    "内容监管",
+    "content regulation",
+    "广播电视统计公报",
+    "broadcasting statistics",
+    "节目制作",
+    "program production",
+    "智能电视",
+    "smart TV",
+    "传媒产业",
+    "media industry"
+  ],
+  "data_content": {
+    "en": [
+      "Annual broadcasting statistics bulletin: total number of licensed radio stations, TV stations, cable and satellite operators nationwide",
+      "Broadcasting coverage rates: radio and television signal coverage by province and rural-urban breakdown",
+      "Cable and IPTV subscribers: number of subscribers to cable TV, satellite direct-to-home, and IPTV services",
+      "Program production volume: hours of original programming produced by category (news, drama, variety, documentary, animation)",
+      "Internet audiovisual platforms: number of licensed platforms offering video-on-demand, live streaming, and online radio services",
+      "Smart TV and connected devices: penetration rates and active users of internet-connected television sets",
+      "Advertising revenue: total advertising income of radio and TV broadcasters",
+      "Industry employment: number of employees in the broadcasting and audiovisual production sector"
+    ],
+    "zh": [
+      "广播电视统计公报：全国持证广播电台、电视台及有线电视、卫星运营机构总量",
+      "广播电视覆盖率：按省份及城乡分类的广播电视信号覆盖情况",
+      "有线及IPTV用户：有线电视、直播卫星和IPTV用户订阅数量",
+      "节目制作播出量：按类别（新闻、电视剧、综艺、纪录片、动画片）分类的原创节目时长",
+      "互联网视听平台：持证视频点播、网络直播和网络广播平台数量",
+      "智能电视与联网终端：互联网电视机普及率和活跃用户数",
+      "广告收入：广播电视播出机构广告经营总收入",
+      "行业就业：广播电视及视听节目制作行业从业人员数量"
+    ]
+  }
+}

--- a/firstdata/sources/china/health/china-ndcpa.json
+++ b/firstdata/sources/china/health/china-ndcpa.json
@@ -9,7 +9,7 @@
     "zh": "国家疾病预防控制局是中国公共卫生监测、疾病预防与控制的中央主管部门，2021年5月在国家卫生健康委领导下正式组建，为副部级机构。在汲取新冠疫情防控经验教训后，承接中国疾病预防控制中心核心职能，以强化国家生物安全和疫情应对治理体系。疾控局负责全国传染病监测报告、国家免疫规划管理、慢性病防控、环境卫生监测和卫生应急准备。定期发布法定传染病疫情通报、疫苗接种覆盖率数据和健康风险评估报告，是中国流行病学数据和公共卫生指标的权威来源。"
   },
   "website": "https://www.ndcpa.gov.cn/",
-  "data_url": "https://www.ndcpa.gov.cn/xxgk/",
+  "data_url": "https://www.ndcpa.gov.cn/jbkzzx/c100016/second/list.html",
   "api_url": null,
   "authority_level": "government",
   "country": "CN",

--- a/firstdata/sources/china/health/china-ndcpa.json
+++ b/firstdata/sources/china/health/china-ndcpa.json
@@ -1,0 +1,72 @@
+{
+  "id": "china-ndcpa",
+  "name": {
+    "en": "National Disease Control and Prevention Administration of China",
+    "zh": "国家疾病预防控制局"
+  },
+  "description": {
+    "en": "The National Disease Control and Prevention Administration (NDCPA) is China's central government authority for public health surveillance, disease prevention and control, established in May 2021 under the National Health Commission as a vice-ministerial-level agency. It took over core functions from the Chinese Center for Disease Control and Prevention (China CDC) to strengthen national biosecurity and epidemic response governance following COVID-19 lessons. NDCPA oversees national communicable disease surveillance and reporting, national immunization program management, chronic disease prevention, environmental health monitoring, and health emergency preparedness. It publishes statutory infectious disease case reports (法定传染病疫情), vaccination coverage data, and health risk assessment reports, making it the authoritative source for China's epidemiological data and public health indicators.",
+    "zh": "国家疾病预防控制局是中国公共卫生监测、疾病预防与控制的中央主管部门，2021年5月在国家卫生健康委领导下正式组建，为副部级机构。在汲取新冠疫情防控经验教训后，承接中国疾病预防控制中心核心职能，以强化国家生物安全和疫情应对治理体系。疾控局负责全国传染病监测报告、国家免疫规划管理、慢性病防控、环境卫生监测和卫生应急准备。定期发布法定传染病疫情通报、疫苗接种覆盖率数据和健康风险评估报告，是中国流行病学数据和公共卫生指标的权威来源。"
+  },
+  "website": "https://www.ndcpa.gov.cn/",
+  "data_url": "https://www.ndcpa.gov.cn/xxgk/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "health",
+    "governance",
+    "social"
+  ],
+  "update_frequency": "monthly",
+  "tags": [
+    "国家疾病预防控制局",
+    "NDCPA",
+    "National Disease Control",
+    "疾控局",
+    "CDC China",
+    "传染病报告",
+    "infectious disease reporting",
+    "法定传染病",
+    "statutory infectious disease",
+    "疫情监测",
+    "epidemic surveillance",
+    "公共卫生",
+    "public health",
+    "疫苗接种",
+    "vaccination",
+    "免疫规划",
+    "immunization program",
+    "慢性病",
+    "chronic disease",
+    "生物安全",
+    "biosafety",
+    "卫生应急",
+    "health emergency",
+    "流行病学",
+    "epidemiology",
+    "疾病预防",
+    "disease prevention"
+  ],
+  "data_content": {
+    "en": [
+      "Monthly statutory infectious disease reports: case counts for 40 nationally notifiable diseases by category (Class A, B, C), province, and pathogen type",
+      "Annual immunization program statistics: vaccination coverage rates for BCG, hepatitis B, polio, DTP, measles-rubella, Japanese encephalitis, and other EPI vaccines by age group and province",
+      "Communicable disease surveillance bulletins: real-time and periodic epidemiological bulletins on influenza, dengue fever, hand-foot-mouth disease, and emerging infectious diseases",
+      "Chronic disease prevalence data: nationwide surveys and monitoring results for hypertension, diabetes, cancer, cardiovascular disease, and obesity",
+      "Environmental health monitoring: reports on ambient air quality health impacts, drinking water safety surveillance, and occupational disease statistics",
+      "Health risk assessments: rapid risk assessments and technical guidance documents for public health events of potential concern",
+      "Biosafety laboratory statistics: data on pathogen detection capacity, biosafety laboratory accreditation, and national reference laboratory networks"
+    ],
+    "zh": [
+      "月度法定传染病疫情通报：按类别（甲乙丙类）、省份和病原体分类的40种法定报告传染病病例数",
+      "年度国家免疫规划统计：按年龄组和省份分类的卡介苗、乙肝、脊髓灰质炎、百白破、麻疹风疹、乙脑等EPI疫苗接种覆盖率",
+      "传染病监测简报：流感、登革热、手足口病及新发传染病实时和定期流行病学通报",
+      "慢性病患病率数据：高血压、糖尿病、癌症、心脑血管疾病和肥胖症全国调查及监测结果",
+      "环境卫生监测：环境空气质量健康影响报告、饮用水安全监测及职业病统计",
+      "健康风险评估：针对潜在突发公共卫生事件的快速风险评估和技术指导文件",
+      "生物安全实验室统计：病原体检测能力、实验室生物安全认证及国家参比实验室网络数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/infrastructure/china-nra.json
+++ b/firstdata/sources/china/infrastructure/china-nra.json
@@ -1,0 +1,75 @@
+{
+  "id": "china-nra",
+  "name": {
+    "en": "National Railway Administration of China",
+    "zh": "国家铁路局"
+  },
+  "description": {
+    "en": "The National Railway Administration (NRA) is China's government regulatory authority for the railway industry, responsible for safety supervision, licensing, technical standards, and industry monitoring across all rail operations including high-speed rail, conventional rail, and urban transit. Established in 2013 under the Ministry of Transport, NRA publishes the Annual Statistical Bulletin on Railway Transportation (铁道统计公报) containing comprehensive data on railway network length, passenger volume, freight tonnage, locomotive and rolling stock inventory, safety incidents, fixed asset investment, and employment. As China operates the world's largest high-speed rail network, NRA's data is critical for understanding China's transportation infrastructure, logistics capacity, and regional economic connectivity.",
+    "zh": "国家铁路局是中国铁路行业的政府监管机构，负责涵盖高铁、普铁和城市轨道交通在内的全路网安全监管、行政许可、技术标准制定和行业监测。2013年在交通运输部领导下组建成立。铁路局每年发布《铁道统计公报》，收录铁路网里程、旅客发送量、货物发送量、机车车辆保有量、安全事故、固定资产投资及从业人员等全面数据。中国已建成全球最大高铁网络，铁路局数据对于研究中国交通基础设施、物流能力和区域经济互联互通具有重要价值。"
+  },
+  "website": "https://www.nra.gov.cn/",
+  "data_url": "https://www.nra.gov.cn/xxgk/gkml/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "transportation",
+    "infrastructure",
+    "economics"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "国家铁路局",
+    "NRA",
+    "National Railway Administration",
+    "铁道统计公报",
+    "railway statistics",
+    "高铁",
+    "high-speed rail",
+    "HSR",
+    "铁路里程",
+    "railway mileage",
+    "旅客发送量",
+    "passenger volume",
+    "货物运输",
+    "freight transport",
+    "铁路投资",
+    "railway investment",
+    "铁路安全",
+    "railway safety",
+    "动车组",
+    "EMU trains",
+    "高铁网络",
+    "HSR network",
+    "铁路运营",
+    "railway operation",
+    "轨道交通",
+    "rail transit",
+    "物流",
+    "logistics"
+  ],
+  "data_content": {
+    "en": [
+      "Railway network length: total operating mileage of national railways, broken down by high-speed rail (250km/h+), electrified lines, double-track lines, and regional distribution",
+      "Passenger statistics: total passenger trips, passenger-kilometers, average trip distance, and breakdown by high-speed vs. conventional rail",
+      "Freight statistics: total freight volume (tonnes), tonne-kilometers, cargo types (coal, grain, steel, containers), and major corridor flows",
+      "Rolling stock inventory: number of locomotives, EMU (high-speed) trainsets, passenger cars, and freight wagons in service",
+      "Fixed asset investment: annual capital expenditure on new line construction, electrification, and infrastructure upgrades",
+      "Station and facility data: number of operating railway stations, maintenance depots, and freight terminals",
+      "Safety statistics: number of railway accidents, casualties, and near-miss incidents by category",
+      "Industry employment: total workforce in the national railway system by function"
+    ],
+    "zh": [
+      "铁路网里程：全国铁路营业里程，按高铁（250公里/小时及以上）、电气化铁路、复线及区域分布细分",
+      "旅客统计：旅客发送量、旅客周转量、平均运距，以及高铁与普铁分类数据",
+      "货物统计：货物发送量（万吨）、货物周转量、货物品类（煤炭、粮食、钢铁、集装箱）及主要通道运量",
+      "机车车辆保有量：在役机车、动车组、客车和货车数量",
+      "固定资产投资：新线建设、电气化改造和基础设施提升年度资本支出",
+      "车站及设施数据：运营铁路客站、维修基地和货运站数量",
+      "安全统计：按类别分类的铁路事故数量、人员伤亡及险情情况",
+      "行业就业：全国铁路系统按职能分类的从业人员总数"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-cae.json
+++ b/firstdata/sources/china/research/china-cae.json
@@ -1,0 +1,72 @@
+{
+  "id": "china-cae",
+  "name": {
+    "en": "Chinese Academy of Engineering",
+    "zh": "中国工程院"
+  },
+  "description": {
+    "en": "The Chinese Academy of Engineering (CAE) is China's highest honorary and consultative academic institution in the field of engineering and technology sciences. Founded in 1994, CAE comprises over 900 elected academicians across nine disciplinary divisions including mechanical and vehicle engineering, information and electronics, chemical and metallurgical engineering, construction and environment, energy and mining, agriculture, medicine and health, and management engineering. CAE publishes the annual China Engineering Science and Technology Development Report (蓝皮书) for key industrial sectors, strategic research reports on national engineering and technology priorities, and the Engineering (工程) academic journal. CAE's advisory reports directly inform national industrial policy, major infrastructure decisions, and technology development roadmaps.",
+    "zh": "中国工程院是中国工程技术领域最高荣誉性和咨询性学术机构，成立于1994年，现有院士900余名，分布于机械与运载、信息与电子、化工冶金与材料、建筑环境与土木、能源与矿业、农业、医药卫生、工程管理等九个学部。中国工程院发布分行业年度《中国工程科技发展报告》（蓝皮书）、国家工程科技重大战略研究报告，主办《Engineering》学术期刊。工程院的咨询报告直接服务于国家产业政策制定、重大基础设施决策和技术发展路线图规划。"
+  },
+  "website": "https://www.cae.cn/",
+  "data_url": "https://www.cae.cn/cae/html/main/col73/column_73_1.html",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "science",
+    "research",
+    "technology"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "中国工程院",
+    "CAE",
+    "Chinese Academy of Engineering",
+    "工程院院士",
+    "CAE academicians",
+    "工程科技蓝皮书",
+    "engineering bluebook",
+    "工程技术",
+    "engineering technology",
+    "战略研究",
+    "strategic research",
+    "产业政策",
+    "industrial policy",
+    "重大工程",
+    "major engineering projects",
+    "技术路线图",
+    "technology roadmap",
+    "中国制造",
+    "Made in China",
+    "智能制造",
+    "intelligent manufacturing",
+    "新材料",
+    "new materials",
+    "新能源",
+    "new energy",
+    "国家重大战略",
+    "national major strategy"
+  ],
+  "data_content": {
+    "en": [
+      "China Engineering Science and Technology Development Report (blue books): annual sector-specific reports on engineering advances in manufacturing, information technology, energy, agriculture, medicine, and construction",
+      "CAE strategic research reports: advisory studies on national engineering and technology priorities submitted to the State Council, covering AI, semiconductors, advanced manufacturing, and green energy transitions",
+      "Academician elections: biennial list of newly elected CAE academicians by discipline, institution affiliation, and research field",
+      "Engineering journal publications: peer-reviewed research articles in the CAE's flagship English-language journal covering major engineering disciplines",
+      "National major engineering project assessments: technical reviews and recommendations on large-scale infrastructure, aerospace, and industrial projects",
+      "Science and technology foresight studies: technology trend forecasting and emerging field identification reports",
+      "Engineering talent statistics: data on engineering workforce, graduate education trends, and R&D personnel in China's engineering sectors"
+    ],
+    "zh": [
+      "中国工程科技发展报告（蓝皮书）：制造业、信息技术、能源、农业、医学和建筑等领域工程技术进展年度分行业报告",
+      "中国工程院战略研究报告：向国务院提交的国家工程科技重大战略咨询研究，涵盖人工智能、半导体、先进制造和绿色能源转型",
+      "院士增选：按学科、所在机构和研究领域分类的双年度新增选院士名单",
+      "《Engineering》期刊成果：工程院旗舰英文期刊发表的涵盖主要工程学科的同行评审研究论文",
+      "国家重大工程项目评估：大型基础设施、航空航天和工业项目技术评审及建议",
+      "工程科技前瞻研究：技术趋势预测和新兴领域识别报告",
+      "工程人才统计：中国工程领域工程技术人员队伍、研究生教育动态及研发人员数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-cas.json
+++ b/firstdata/sources/china/research/china-cas.json
@@ -1,0 +1,75 @@
+{
+  "id": "china-cas",
+  "name": {
+    "en": "Chinese Academy of Sciences - Science Data Bank",
+    "zh": "中国科学院科学数据库"
+  },
+  "description": {
+    "en": "The Chinese Academy of Sciences (CAS) is China's highest academic institution and national comprehensive research center for natural sciences, with over 100 research institutes across disciplines. CAS operates the CAS Science Data Bank (scidb.cn), a national open science data repository that aggregates research datasets from CAS institutes covering earth sciences, astronomy, physics, chemistry, biology, ecology, materials science, and ocean sciences. The platform provides free access to peer-reviewed scientific datasets produced by China's premier research institutions, supporting reproducibility of published findings and enabling data-driven research across disciplines. CAS also publishes the annual China Science and Technology Development Report and manages several domain-specific data centers recognized as national scientific data centers.",
+    "zh": "中国科学院是中国自然科学领域最高学术机构和国家综合性科研中心，设有100余个研究院所。中科院运营科学数据库（scidb.cn），这是一个汇聚各研究院所科研数据集的国家开放科学数据仓储平台，覆盖地球科学、天文学、物理、化学、生物、生态、材料科学和海洋科学等领域。平台提供中国顶尖科研机构产出的同行评审数据集免费访问服务，支持已发表成果的可重复性验证，促进跨学科数据驱动研究。中科院同时发布年度《中国科学技术发展报告》，并管理多个被认定为国家科学数据中心的专题数据中心。"
+  },
+  "website": "https://www.cas.cn/",
+  "data_url": "https://www.scidb.cn/",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "science",
+    "research",
+    "environment"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国科学院",
+    "CAS",
+    "Chinese Academy of Sciences",
+    "科学数据库",
+    "Science Data Bank",
+    "scidb",
+    "科研数据",
+    "research data",
+    "开放科学",
+    "open science",
+    "地球科学",
+    "earth science",
+    "生态数据",
+    "ecological data",
+    "天文数据",
+    "astronomical data",
+    "材料科学",
+    "materials science",
+    "海洋科学",
+    "ocean science",
+    "国家科学数据中心",
+    "national science data center",
+    "可重复性",
+    "reproducibility",
+    "中国科研",
+    "China research",
+    "基础研究",
+    "basic research"
+  ],
+  "data_content": {
+    "en": [
+      "Earth and environmental science datasets: atmospheric chemistry, soil surveys, watershed hydrology, glacier monitoring, and land use change data from CAS field stations",
+      "Astronomy and space science data: observational data from NAOC telescopes, space mission telemetry from NSSC, and sky survey catalogs",
+      "Biological and ecological datasets: species distribution records, biodiversity surveys, ecosystem monitoring from China's Ecosystem Research Network (CERN)",
+      "Materials science data: crystallographic databases, materials properties datasets from CAS institutes including NIMTE and IMR",
+      "Ocean science datasets: observational data from South China Sea Institute, deep-sea survey data, and marine biogeochemistry records",
+      "Physics and chemistry research data: experimental datasets from major CAS research facilities and national laboratories",
+      "China Science and Technology Development Report: annual statistical report on R&D investment, patent output, publication counts, and technology transfer",
+      "National scientific data center outputs: domain-specific curated datasets from CAS-managed centers for high-energy physics, genomics, and remote sensing"
+    ],
+    "zh": [
+      "地球与环境科学数据集：大气化学、土壤调查、流域水文、冰川监测及来自中科院野外台站的土地利用变化数据",
+      "天文与空间科学数据：国家天文台望远镜观测数据、国家空间科学中心空间任务遥测及巡天星表",
+      "生物与生态数据集：物种分布记录、生物多样性调查及中国生态系统研究网络（CERN）生态系统监测数据",
+      "材料科学数据：晶体学数据库，以及来自宁波材料技术与工程研究所、金属研究所等中科院院所的材料性能数据集",
+      "海洋科学数据集：南海海洋研究所观测数据、深海调查数据及海洋生物地球化学记录",
+      "物理与化学研究数据：来自中科院重大科研装置和国家实验室的实验数据集",
+      "中国科学技术发展报告：研发投入、专利产出、论文发表量及技术转移情况年度统计报告",
+      "国家科学数据中心成果：高能物理、基因组学、遥感等中科院管理的专题数据中心精选数据集"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds 5 authoritative Chinese government/institutional data sources as part of daily contribution batch (AM, 2026-04-06).

## New Sources

| ID | Name (EN) | Name (ZH) | Domain | URL |
|---|---|---|---|---|
| `china-nrta` | National Radio and Television Administration | 国家广播电视总局 | media, governance | nrta.gov.cn |
| `china-nra` | National Railway Administration | 国家铁路局 | transportation, infrastructure | nra.gov.cn |
| `china-cas` | Chinese Academy of Sciences - Science Data Bank | 中国科学院科学数据库 | science, research | scidb.cn |
| `china-cae` | Chinese Academy of Engineering | 中国工程院 | science, research, technology | cae.cn |
| `china-ndcpa` | National Disease Control and Prevention Administration | 国家疾病预防控制局 | health, governance | ndcpa.gov.cn |

## Validation

- [x] All IDs checked for duplicates via `check-candidate.sh` (all AVAILABLE)
- [x] All URLs verified accessible (200/403 acceptable for CN gov sites)
- [x] `make check` passed: 379 unique IDs, all files valid
- [x] Schema compliant: `name` only has `en`/`zh` fields, domains use lowercase-hyphen
- [x] Files placed in correct `china/` subdirectories