### PR TITLE
feat: add 3 new data sources

### DIFF
--- a/firstdata/sources/countries/asia/japan/japan-fsa.json
+++ b/firstdata/sources/countries/asia/japan/japan-fsa.json
@@ -1,0 +1,59 @@
+{
+  "id": "japan-fsa",
+  "name": {
+    "en": "Japan Financial Services Agency",
+    "zh": "日本金融厅"
+  },
+  "description": {
+    "en": "The Financial Services Agency (FSA) is the Japanese government body responsible for overseeing banking, securities, exchange, and insurance sectors. It publishes regulatory data, financial institution statistics, corporate disclosure filings (EDINET), inspection results, and policy documents essential for understanding Japan's financial regulatory landscape.",
+    "zh": "日本金融厅（FSA）是负责监管日本银行、证券、交易所和保险行业的政府机构。发布监管数据、金融机构统计、企业信息披露文件（EDINET）、检查结果和政策文件，是了解日本金融监管环境的关键数据源。"
+  },
+  "website": "https://www.fsa.go.jp/en/",
+  "data_url": "https://www.fsa.go.jp/en/refer/index.html",
+  "api_url": null,
+  "country": "JP",
+  "authority_level": "government",
+  "domains": [
+    "finance",
+    "banking",
+    "securities",
+    "insurance",
+    "regulation"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "Japan",
+    "financial-regulation",
+    "banking-supervision",
+    "securities",
+    "insurance",
+    "EDINET",
+    "corporate-disclosure",
+    "金融厅",
+    "金融監管",
+    "日本金融"
+  ],
+  "data_content": {
+    "en": [
+      "Banking sector statistics and supervision reports",
+      "Securities and exchange regulation data",
+      "Insurance industry statistics",
+      "EDINET corporate disclosure filings",
+      "Financial institution inspection results",
+      "Anti-money laundering and compliance data",
+      "Financial system stability reports",
+      "Policy and regulatory documents"
+    ],
+    "zh": [
+      "银行业统计和监管报告",
+      "证券和交易所监管数据",
+      "保险行业统计",
+      "EDINET企业信息披露文件",
+      "金融机构检查结果",
+      "反洗钱和合规数据",
+      "金融系统稳定性报告",
+      "政策和监管文件"
+    ]
+  }
+}

--- a/firstdata/sources/countries/asia/japan/japan-gpif.json
+++ b/firstdata/sources/countries/asia/japan/japan-gpif.json
@@ -1,0 +1,59 @@
+{
+  "id": "japan-gpif",
+  "name": {
+    "en": "Government Pension Investment Fund",
+    "zh": "日本政府养老投资基金"
+  },
+  "description": {
+    "en": "The Government Pension Investment Fund (GPIF) is the world's largest pension fund, managing Japan's public pension reserves. It publishes detailed investment performance data, asset allocation reports, ESG investment activities, stewardship reports, and research on long-term investment strategies. GPIF's portfolio movements significantly influence global financial markets.",
+    "zh": "日本政府养老投资基金（GPIF）是全球最大的养老基金，管理日本公共养老金储备。发布详细的投资业绩数据、资产配置报告、ESG投资活动、管理责任报告以及长期投资策略研究。GPIF的组合变动对全球金融市场有重大影响。"
+  },
+  "website": "https://www.gpif.go.jp/en/",
+  "data_url": "https://www.gpif.go.jp/en/performance/",
+  "api_url": null,
+  "country": "JP",
+  "authority_level": "government",
+  "domains": [
+    "finance",
+    "pension",
+    "investment",
+    "esg"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "quarterly",
+  "tags": [
+    "Japan",
+    "pension-fund",
+    "GPIF",
+    "sovereign-wealth",
+    "asset-allocation",
+    "ESG",
+    "investment-performance",
+    "public-pension",
+    "年金",
+    "养老基金",
+    "资产配置"
+  ],
+  "data_content": {
+    "en": [
+      "Quarterly and annual investment performance reports",
+      "Asset allocation by domestic/foreign bonds and equities",
+      "Benchmark return comparisons",
+      "ESG activity reports and initiatives",
+      "Stewardship responsibility reports",
+      "Alternative investment portfolio data",
+      "Investment manager selection and evaluation",
+      "Long-term investment strategy research papers"
+    ],
+    "zh": [
+      "季度和年度投资业绩报告",
+      "国内外债券和股票资产配置",
+      "基准收益对比",
+      "ESG活动报告和倡议",
+      "管理责任报告",
+      "另类投资组合数据",
+      "投资管理人选择和评估",
+      "长期投资策略研究论文"
+    ]
+  }
+}

--- a/firstdata/sources/countries/asia/japan/jpx.json
+++ b/firstdata/sources/countries/asia/japan/jpx.json
@@ -1,0 +1,64 @@
+{
+  "id": "jpx",
+  "name": {
+    "en": "Japan Exchange Group",
+    "zh": "日本交易所集团"
+  },
+  "description": {
+    "en": "Japan Exchange Group (JPX) operates the Tokyo Stock Exchange (TSE) and Osaka Exchange (OSE), forming one of the world's largest exchange groups. It provides comprehensive market statistics including equity trading data, listed company information, market indices (TOPIX, Nikkei), derivatives statistics, IPO data, and corporate governance reports.",
+    "zh": "日本交易所集团（JPX）运营东京证券交易所（TSE）和大阪交易所（OSE），是全球最大的交易所集团之一。提供全面的市场统计数据，包括股票交易数据、上市公司信息、市场指数（TOPIX、日经）、衍生品统计、IPO数据和公司治理报告。"
+  },
+  "website": "https://www.jpx.co.jp/english/",
+  "data_url": "https://www.jpx.co.jp/english/markets/statistics-equities/index.html",
+  "api_url": null,
+  "country": "JP",
+  "authority_level": "market",
+  "domains": [
+    "finance",
+    "securities",
+    "stock-market",
+    "derivatives"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "daily",
+  "tags": [
+    "Japan",
+    "stock-exchange",
+    "TSE",
+    "Tokyo-Stock-Exchange",
+    "TOPIX",
+    "Nikkei",
+    "equities",
+    "derivatives",
+    "IPO",
+    "market-data",
+    "東京証券取引所",
+    "日本交易所"
+  ],
+  "data_content": {
+    "en": [
+      "Equity market trading statistics (volume, value, turnover)",
+      "Listed company information and filings",
+      "Market indices (TOPIX, JPX-Nikkei Index 400)",
+      "Derivatives trading statistics (futures, options)",
+      "IPO and new listing data",
+      "Corporate governance reports",
+      "Foreign investor trading statistics",
+      "Short selling reports",
+      "Margin trading statistics",
+      "ETF and REIT market data"
+    ],
+    "zh": [
+      "股票市场交易统计（成交量、成交额、换手率）",
+      "上市公司信息和公告文件",
+      "市场指数（TOPIX、JPX日经400指数）",
+      "衍生品交易统计（期货、期权）",
+      "IPO和新上市数据",
+      "公司治理报告",
+      "外国投资者交易统计",
+      "卖空报告",
+      "融资融券统计",
+      "ETF和REIT市场数据"
+    ]
+  }
+}


### PR DESCRIPTION
## New Data Sources

Add 3 new authoritative data sources for Japan:

1. **japan-fsa** — Japan Financial Services Agency (日本金融厅): Government financial regulatory body, publishes banking/securities/insurance supervision data and EDINET corporate disclosures.

2. **jpx** — Japan Exchange Group (日本交易所集团): Operates Tokyo Stock Exchange and Osaka Exchange. Provides equity/derivatives trading statistics, market indices (TOPIX), IPO data.

3. **japan-gpif** — Government Pension Investment Fund (日本政府养老投资基金): World's largest pension fund. Publishes investment performance, asset allocation, and ESG reports.

### Source
Identified from Langfuse MCP usage analysis (2026-04-09 traces).

### Checklist
- [x] Schema validation passed (`make check`)
- [x] No duplicate IDs (`make check-ids`)
- [x] All URLs verified accessible
- [x] No `native` field in name objects
- [x] Domains lowercase with hyphens
- [x] Correct directory: `countries/asia/japan/`