### PR TITLE
fix: correct china-gz-stats website (广州市→贵州省)

### DIFF
--- a/firstdata/sources/china/economy/provincial/china-gz-stats.json
+++ b/firstdata/sources/china/economy/provincial/china-gz-stats.json
@@ -8,7 +8,7 @@
     "en": "The Guizhou Bureau of Statistics is the official statistical authority for Guizhou Province, a mountainous province in southwestern China that has experienced remarkable transformation from one of China's poorest regions to a leading hub for big data, cloud computing, and digital economy. Guizhou is also renowned for Maotai liquor production and tourism. The bureau publishes comprehensive socioeconomic statistics covering GDP, digital economy indicators, poverty alleviation outcomes, tourism revenue, industrial output, population, and agricultural data. It also releases the Guizhou Statistical Yearbook and thematic reports on big data industry development.",
     "zh": "贵州省统计局是贵州省官方统计机构，贵州是中国西南部山区省份，从中国最贫困地区之一成功转型为大数据、云计算和数字经济的重要枢纽，同时以茅台酒生产和旅游业著称。统计局发布贵州省GDP、数字经济指标、脱贫攻坚成效、旅游收入、工业产值、人口和农业数据等全面社会经济统计，并出版《贵州统计年鉴》及大数据产业发展专题报告。"
   },
-  "website": "https://tjj.gz.gov.cn/",
+  "website": "https://stjj.guizhou.gov.cn/",
   "data_url": "https://stjj.guizhou.gov.cn/tjsj/",
   "api_url": null,
   "authority_level": "government",


### PR DESCRIPTION
website字段错误指向广州市统计局(tjj.gz.gov.cn)，实际应为贵州省统计局(stjj.guizhou.gov.cn)。data_url已正确。