### PR TITLE
feat: add 5 Chinese data sources (PM batch, 2026-04-14)

### DIFF
--- a/firstdata/sources/china/finance/securities/china-neeq.json
+++ b/firstdata/sources/china/finance/securities/china-neeq.json
@@ -1,0 +1,74 @@
+{
+  "id": "china-neeq",
+  "name": {
+    "en": "National Equities Exchange and Quotations (New Third Board)",
+    "zh": "全国中小企业股份转让系统（新三板）"
+  },
+  "description": {
+    "en": "The National Equities Exchange and Quotations (NEEQ), commonly known as the New Third Board (新三板), is China's national OTC securities market for small and medium-sized enterprises (SMEs). Established in 2013 and supervised by the China Securities Regulatory Commission (CSRC), NEEQ provides a capital market platform for innovative SMEs that do not yet meet requirements for listing on the main exchanges. It publishes real-time quotation data, company disclosure information, and market statistics for thousands of listed companies.",
+    "zh": "全国中小企业股份转让系统（NEEQ），俗称新三板，是中国为中小企业设立的全国性场外证券市场。成立于2013年，受中国证券监督管理委员会监管，为尚不满足主板上市要求的创新型中小企业提供资本市场平台。提供数千家挂牌公司的实时行情数据、信息披露和市场统计数据。"
+  },
+  "website": "https://www.neeq.com.cn",
+  "data_url": "https://www.neeq.com.cn/issuanceList.html",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "finance",
+    "securities"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "新三板",
+    "New Third Board",
+    "NEEQ",
+    "全国股转",
+    "中小企业",
+    "SME",
+    "场外市场",
+    "OTC market",
+    "挂牌公司",
+    "listed companies",
+    "股票行情",
+    "stock quotations",
+    "证券",
+    "securities",
+    "中国资本市场",
+    "China capital market",
+    "做市商",
+    "market maker",
+    "精选层",
+    "创新层",
+    "基础层",
+    "北交所",
+    "信息披露",
+    "disclosure"
+  ],
+  "data_content": {
+    "en": [
+      "Market Overview - Total listed companies, market capitalization, and trading volume statistics",
+      "Real-time Quotations - Bid/ask prices, last trade prices, and volume for all listed stocks",
+      "Company Disclosure - Annual reports, interim reports, prospectuses, and material event announcements",
+      "Listing Information - New listings, de-listings, and transfer-to-exchange records",
+      "Fundraising Statistics - Equity financing amounts and deal counts by period",
+      "Industry Distribution - Listed company counts and market cap by CSRC industry classification",
+      "Regional Distribution - Listed company statistics by province and city",
+      "Market Maker Data - Market maker quotes, spreads, and turnover for designated stocks",
+      "Index Data - NEEQ composite index and selected tier indices",
+      "Annual Market Reports - Comprehensive annual statistics on SME equity financing in China"
+    ],
+    "zh": [
+      "市场概况 - 挂牌公司总数、市值和成交量统计",
+      "实时行情 - 所有挂牌股票的买卖报价、最新成交价和成交量",
+      "信息披露 - 年报、半年报、招股说明书和重大事项公告",
+      "挂牌信息 - 新增挂牌、摘牌和转板记录",
+      "融资统计 - 各期间股权融资金额和交易笔数",
+      "行业分布 - 按证监会行业分类的挂牌公司数量和市值",
+      "地区分布 - 按省市划分的挂牌公司统计",
+      "做市商数据 - 做市股票的做市商报价、价差和成交数据",
+      "指数数据 - 新三板综合指数及各层次选取指数",
+      "年度市场报告 - 中国中小企业股权融资年度综合统计"
+    ]
+  }
+}

--- a/firstdata/sources/china/governance/china-acla.json
+++ b/firstdata/sources/china/governance/china-acla.json
@@ -1,0 +1,71 @@
+{
+  "id": "china-acla",
+  "name": {
+    "en": "All China Lawyers Association",
+    "zh": "中华全国律师协会"
+  },
+  "description": {
+    "en": "The All China Lawyers Association (ACLA) is the national self-regulatory organization for the legal profession in China, established in 1986. Under the supervision of the Ministry of Justice, ACLA represents and manages approximately 650,000 licensed lawyers and over 40,000 law firms across China. It publishes annual statistics on the legal profession including lawyer counts by region, law firm distribution, legal aid cases, and industry growth trends, serving as the authoritative data source for China's legal services market.",
+    "zh": "中华全国律师协会（全国律协/ACLA）成立于1986年，是中国法律职业的全国性自律组织，受司法部监管。代表和管理全国约65万名执业律师和4万余家律师事务所。发布全国律师行业年度统计数据，包括各地区律师人数、律师事务所分布、法律援助案件情况和行业发展趋势，是中国法律服务市场的权威数据来源。"
+  },
+  "website": "https://www.acla.org.cn",
+  "data_url": "https://www.acla.org.cn/acla/tjxx/",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "legal",
+    "governance"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "律师",
+    "lawyer",
+    "法律服务",
+    "legal services",
+    "律师事务所",
+    "law firm",
+    "全国律协",
+    "ACLA",
+    "司法",
+    "judicial",
+    "法律援助",
+    "legal aid",
+    "律师统计",
+    "lawyer statistics",
+    "中国法律",
+    "China legal",
+    "执业律师",
+    "licensed attorney",
+    "法律职业",
+    "legal profession",
+    "律师行业",
+    "律师人数",
+    "律师分布"
+  ],
+  "data_content": {
+    "en": [
+      "Lawyer Statistics - Annual count of licensed lawyers nationwide and by province/city",
+      "Law Firm Distribution - Number and size of law firms across provinces, cities, and counties",
+      "Legal Aid Data - Legal aid cases handled, recipients served, and geographic distribution",
+      "Professional Development - New admissions, annual continuing education completion rates",
+      "Specialization Areas - Distribution of lawyers across practice areas (criminal, civil, commercial, IP, etc.)",
+      "Industry Revenue - Total revenue of China's legal services industry and per-lawyer metrics",
+      "Foreign Law Firms - Number and distribution of foreign law firm representative offices in China",
+      "Disciplinary Actions - Lawyer disciplinary cases and outcomes by category",
+      "International Cooperation - Cross-border legal service statistics and bilateral agreements"
+    ],
+    "zh": [
+      "律师统计 - 全国及各省市执业律师年度人数",
+      "律师事务所分布 - 全国各省市县律师事务所数量和规模",
+      "法律援助数据 - 法律援助案件办理数量、受援对象和地域分布",
+      "队伍建设 - 新增执业律师数量、年度继续教育完成情况",
+      "业务领域分布 - 律师在刑事、民事、商事、知识产权等领域的分布",
+      "行业收入 - 法律服务行业总收入和人均创收指标",
+      "外国律师事务所 - 外国律师事务所在华代表机构数量和分布",
+      "惩戒处分 - 按类型分类的律师惩戒案件和处理结果",
+      "国际合作 - 跨境法律服务统计和双边合作协议情况"
+    ]
+  }
+}

--- a/firstdata/sources/china/national/meteorology/china-nsmc.json
+++ b/firstdata/sources/china/national/meteorology/china-nsmc.json
@@ -1,0 +1,74 @@
+{
+  "id": "china-nsmc",
+  "name": {
+    "en": "National Satellite Meteorological Center of China",
+    "zh": "国家卫星气象中心"
+  },
+  "description": {
+    "en": "The National Satellite Meteorological Center (NSMC), under the China Meteorological Administration, is responsible for operating China's FengYun (FY) series of meteorological satellites and providing satellite-derived meteorological and environmental data products. NSMC operates both geostationary satellites (FY-2, FY-4) and polar-orbiting satellites (FY-1, FY-3), providing global and regional data for weather forecasting, climate monitoring, disaster warning, and environmental surveillance.",
+    "zh": "国家卫星气象中心（NSMC）隶属于中国气象局，负责运营中国风云系列气象卫星并提供卫星遥感气象与环境数据产品。中心运营静止轨道卫星（风云二号、风云四号）和极轨卫星（风云一号、风云三号），为天气预报、气候监测、灾害预警和环境监测提供全球和区域数据。"
+  },
+  "website": "https://www.nsmc.org.cn",
+  "data_url": "https://www.nsmc.org.cn/nsmc/cn/satellite/index.html",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "global",
+  "domains": [
+    "meteorology",
+    "climate",
+    "remote-sensing"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "风云卫星",
+    "FengYun",
+    "气象卫星",
+    "meteorological satellite",
+    "卫星遥感",
+    "satellite remote sensing",
+    "气象数据",
+    "weather data",
+    "气候监测",
+    "climate monitoring",
+    "灾害预警",
+    "disaster warning",
+    "FY-2",
+    "FY-3",
+    "FY-4",
+    "NSMC",
+    "国家卫星气象中心",
+    "云图",
+    "satellite imagery",
+    "大气探测",
+    "atmospheric sounding"
+  ],
+  "data_content": {
+    "en": [
+      "FengYun Satellite Products - Real-time and archived satellite imagery from FY-2, FY-3, and FY-4 series",
+      "Cloud Analysis Products - Cloud top temperature, cloud type classification, and cloud cover maps",
+      "Precipitation Estimation - Satellite-derived rainfall and snowfall estimates at national and global scale",
+      "Land Surface Temperature - Daily and composite land surface temperature products",
+      "Sea Surface Temperature - Ocean surface temperature monitoring using FY satellite data",
+      "Vegetation Index (NDVI) - National and global vegetation health monitoring products",
+      "Snow and Ice Cover - Extent and depth monitoring for polar and mountain regions",
+      "Atmospheric Motion Vectors - Upper-level wind field data derived from consecutive satellite images",
+      "Fire Detection Products - Active fire points and burned area estimates from satellite thermal channels",
+      "Dust and Aerosol Products - Sand-dust storm tracking, aerosol optical depth mapping",
+      "Typhoon Monitoring - Real-time typhoon track, intensity, and structural analysis"
+    ],
+    "zh": [
+      "风云卫星产品 - 风云二号、三号、四号系列卫星实时和存档遥感图像",
+      "云分析产品 - 云顶温度、云型分类和云覆盖图",
+      "降水估算 - 国家和全球尺度卫星遥感降雨和降雪估算",
+      "地表温度 - 日产品和合成地表温度产品",
+      "海面温度 - 基于风云卫星数据的海洋表面温度监测",
+      "植被指数（NDVI）- 国家和全球植被健康监测产品",
+      "雪冰覆盖 - 极地和山区雪冰范围与厚度监测",
+      "大气运动矢量 - 基于连续卫星图像的高层风场数据",
+      "火点探测产品 - 卫星热通道主动火点和过火面积估算",
+      "沙尘与气溶胶产品 - 沙尘暴路径追踪、气溶胶光学厚度制图",
+      "台风监测 - 台风路径、强度和结构实时分析"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/environment/china-cnemc.json
+++ b/firstdata/sources/china/resources/environment/china-cnemc.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-cnemc",
+  "name": {
+    "en": "China National Environmental Monitoring Centre",
+    "zh": "中国环境监测总站"
+  },
+  "description": {
+    "en": "The China National Environmental Monitoring Centre (CNEMC) is the national technical support agency under the Ministry of Ecology and Environment (MEE), responsible for operating China's national environmental monitoring network. CNEMC publishes real-time and historical data on air quality, surface water quality, soil, and acoustic environment across more than 1,600 monitoring stations nationwide. It provides authoritative environmental quality data supporting policy decisions, public health protection, and pollution control enforcement.",
+    "zh": "中国环境监测总站（CNEMC）是生态环境部下属的国家环境监测技术支撑机构，负责运营覆盖全国1600余个站点的国家环境监测网络。发布空气质量、地表水质、土壤和声环境的实时及历史监测数据，为政策决策、公众健康保护和污染防治执法提供权威环境质量数据。"
+  },
+  "website": "https://www.cnemc.cn",
+  "data_url": "https://www.cnemc.cn/sssj/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "environment",
+    "public-health"
+  ],
+  "update_frequency": "real-time",
+  "tags": [
+    "环境监测",
+    "environmental monitoring",
+    "空气质量",
+    "air quality",
+    "AQI",
+    "PM2.5",
+    "PM10",
+    "水质监测",
+    "water quality",
+    "地表水",
+    "surface water",
+    "土壤监测",
+    "soil monitoring",
+    "声环境",
+    "noise monitoring",
+    "实时数据",
+    "real-time data",
+    "CNEMC",
+    "中国环境监测总站",
+    "生态环境部",
+    "国控站",
+    "national monitoring station",
+    "污染",
+    "pollution",
+    "六项污染物",
+    "six pollutants"
+  ],
+  "data_content": {
+    "en": [
+      "Real-time Air Quality Index (AQI) - Hourly AQI values for 338+ cities and 1,600+ monitoring stations nationwide",
+      "Six Criteria Pollutants - Real-time concentrations of PM2.5, PM10, SO2, NO2, CO, and O3",
+      "Air Quality Rankings - Daily and monthly city rankings by air quality",
+      "Historical Air Quality Data - Hourly, daily, and monthly historical pollutant data by city and station",
+      "Surface Water Quality - Real-time monitoring at key river basins including Yangtze, Yellow, Pearl, and Hai Rivers",
+      "Groundwater Quality - Monitoring data from national groundwater quality assessment network",
+      "Drinking Water Source Quality - Surveillance data for municipal drinking water sources",
+      "Acoustic Environment Monitoring - Urban noise levels at functional zone monitoring points",
+      "Annual Environmental Quality Bulletins - Comprehensive national environmental quality reports",
+      "Soil Pollution Monitoring - Results from national soil pollution status surveys"
+    ],
+    "zh": [
+      "实时空气质量指数（AQI）- 全国338个城市及1600余个监测站的逐时AQI数据",
+      "六项大气污染物 - PM2.5、PM10、SO2、NO2、CO、O3实时浓度",
+      "空气质量排名 - 城市日排名和月排名",
+      "历史空气质量数据 - 按城市和站点的逐时、日均、月均历史污染物数据",
+      "地表水水质 - 长江、黄河、珠江、海河等重点流域实时监测",
+      "地下水水质 - 国家地下水水质评估网络监测数据",
+      "集中式饮用水水源地水质 - 城市饮用水水源地监测数据",
+      "声环境监测 - 各功能区城市噪声监测数据",
+      "年度环境质量公报 - 综合性国家环境质量年度报告",
+      "土壤污染监测 - 全国土壤污染状况详查结果"
+    ]
+  }
+}

--- a/firstdata/sources/china/technology/industry_associations/china-csee.json
+++ b/firstdata/sources/china/technology/industry_associations/china-csee.json
@@ -1,0 +1,77 @@
+{
+  "id": "china-csee",
+  "name": {
+    "en": "Chinese Society for Electrical Engineering",
+    "zh": "中国电机工程学会"
+  },
+  "description": {
+    "en": "The Chinese Society for Electrical Engineering (CSEE), founded in 1934, is China's leading national academic and professional society for electrical engineering, power systems, and energy. With over 100,000 members and affiliated with the China Association for Science and Technology (CAST), CSEE publishes technical standards, research reports, and industry statistics covering power generation, transmission, distribution, smart grids, renewable energy integration, and electrical equipment. It also serves as China's national member in the International Electrotechnical Commission (IEC) and the Union Internationale d'Electrothermie (UIE).",
+    "zh": "中国电机工程学会（CSEE）成立于1934年，是中国电气工程、电力系统和能源领域最重要的全国性学术和专业组织，会员逾10万人，隶属于中国科学技术协会。发布涵盖发电、输电、配电、智能电网、可再生能源并网和电气设备的技术标准、研究报告和行业统计。同时是国际电工委员会（IEC）和国际电热联合会（UIE）的中国全国会员。"
+  },
+  "website": "https://www.csee.org.cn",
+  "data_url": "https://www.csee.org.cn/",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "energy",
+    "technology"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "电力",
+    "power",
+    "电气工程",
+    "electrical engineering",
+    "智能电网",
+    "smart grid",
+    "可再生能源",
+    "renewable energy",
+    "电力系统",
+    "power system",
+    "CSEE",
+    "中国电机工程学会",
+    "发电",
+    "generation",
+    "输电",
+    "transmission",
+    "配电",
+    "distribution",
+    "新能源",
+    "new energy",
+    "储能",
+    "energy storage",
+    "电力技术",
+    "power technology",
+    "IEC",
+    "标准",
+    "standards"
+  ],
+  "data_content": {
+    "en": [
+      "Annual Power Industry Reports - Comprehensive statistics on China's electricity generation, consumption, and grid infrastructure",
+      "Renewable Energy Integration - Data on wind, solar, and hydro power connectivity and curtailment rates",
+      "Smart Grid Development - Reports on advanced metering infrastructure, EV charging, and grid automation progress",
+      "Power Equipment Statistics - Installed capacity by generation type (thermal, hydro, nuclear, wind, solar)",
+      "Grid Investment Data - Annual capital expenditure data for transmission and distribution infrastructure",
+      "Carbon Emission Factors - Power sector CO2 emission intensity by regional grid",
+      "Technical Standards - CSEE-published electrical engineering standards and technical guidelines",
+      "Academic Publications - Peer-reviewed journals including Proceedings of the CSEE (中国电机工程学报)",
+      "Conference Proceedings - Technical papers from major power engineering conferences in China",
+      "Industry Talent Reports - Annual statistics on electrical engineering workforce and education"
+    ],
+    "zh": [
+      "年度电力行业报告 - 中国发电量、用电量和电网基础设施综合统计",
+      "新能源并网 - 风电、光伏和水电接入及弃能率数据",
+      "智能电网发展 - 高级计量设施、电动汽车充电桩和电网自动化进展报告",
+      "电力装备统计 - 按发电类型（火电、水电、核电、风电、光伏）划分的装机容量",
+      "电网投资数据 - 输电和配电基础设施年度资本支出",
+      "碳排放因子 - 各区域电网电力行业CO2排放强度",
+      "技术标准 - 中国电机工程学会发布的电气工程标准和技术规范",
+      "学术出版物 - 《中国电机工程学报》等同行评审期刊",
+      "会议论文集 - 中国主要电力工程会议技术论文",
+      "行业人才报告 - 电气工程从业人员和教育情况年度统计"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

午后批次：新增 5 个中国权威数据源

## New Sources

| ID | Name (EN) | Name (ZH) | Authority | Domain |
|---|---|---|---|---|
| china-nsmc | National Satellite Meteorological Center | 国家卫星气象中心 | government | meteorology, climate, remote-sensing |
| china-neeq | National Equities Exchange and Quotations (New Third Board) | 全国中小企业股份转让系统（新三板） | market | finance, securities |
| china-cnemc | China National Environmental Monitoring Centre | 中国环境监测总站 | government | environment, public-health |
| china-acla | All China Lawyers Association | 中华全国律师协会 | other | legal, governance |
| china-csee | Chinese Society for Electrical Engineering | 中国电机工程学会 | research | energy, technology |

## Validation

- ✅ All 5 IDs are unique (check-candidate.sh passed)
- ✅ All blacklist checks passed (check-blacklist.sh)
- ✅ All URLs verified accessible (200/301/302/403)
- ✅ make check passed (443 unique IDs, valid JSON, consistent domains)
- ✅ No `native` field in name objects
- ✅ Domains use lowercase + hyphens only