### PR TITLE
feat: add 5 Chinese government data sources (AM batch, 2026-04-16)

### DIFF
--- a/firstdata/sources/china/economy/trade/china-sinosure.json
+++ b/firstdata/sources/china/economy/trade/china-sinosure.json
@@ -1,0 +1,73 @@
+{
+  "id": "china-sinosure",
+  "name": {
+    "en": "China Export & Credit Insurance Corporation",
+    "zh": "中国出口信用保险公司"
+  },
+  "description": {
+    "en": "China Export & Credit Insurance Corporation (Sinosure) is a state-owned policy insurance company established by the Chinese government to support China's foreign trade, investment, and economic cooperation by providing export credit insurance and investment guarantee services. As China's sole provider of policy-based export credit insurance, Sinosure publishes annual reports containing authoritative data on export credit insurance coverage by country, industry, and enterprise type, as well as country risk assessments, loss and compensation data, and overseas investment insurance statistics. Sinosure's country risk classifications and export data coverage represent unique intelligence on the credit risk landscape of China's global trade partners.",
+    "zh": "中国出口信用保险公司（中国信保）是国家出资设立的政策性保险机构，通过提供出口信用保险和投资保证服务，支持中国的对外贸易、投资和经济合作。作为中国唯一的政策性出口信用保险机构，中国信保发布年度报告，提供按国家、行业和企业类型分类的出口信用保险承保数据，以及国家风险评级、损失赔偿数据和境外投资保险统计。中国信保的国家风险分类和出口数据覆盖情况，是了解中国全球贸易伙伴信用风险状况的独特信息来源。"
+  },
+  "website": "https://www.sinosure.com.cn",
+  "data_url": "https://www.sinosure.com.cn/gywm/gsjj/xxpl/index.shtml",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "trade",
+    "finance",
+    "economics"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "出口信用保险",
+    "export credit insurance",
+    "国家风险",
+    "country risk",
+    "出口保障",
+    "export guarantee",
+    "境外投资",
+    "overseas investment",
+    "贸易融资",
+    "trade finance",
+    "短期险",
+    "short-term insurance",
+    "中长期险",
+    "medium-long term insurance",
+    "债务人风险",
+    "buyer risk",
+    "赔偿数据",
+    "claims data",
+    "信用评级",
+    "credit rating",
+    "对外贸易",
+    "foreign trade",
+    "政策性保险",
+    "policy insurance",
+    "Sinosure",
+    "中国信保"
+  ],
+  "data_content": {
+    "en": [
+      "Export credit insurance coverage statistics: annual premium income, total insured export value, and number of insured exporters by policy type (short-term, medium-to-long-term, overseas investment insurance) with historical comparison",
+      "Country risk assessments and classifications: Sinosure's proprietary country risk ratings covering 200+ countries and territories, categorized by political risk, transfer risk, and commercial risk with annual updates",
+      "Geographic distribution of export insurance coverage: insured export value broken down by destination country and region, highlighting coverage in Belt and Road Initiative countries, African markets, and emerging economies",
+      "Industry sector coverage data: export insurance penetration rates and insured value by major export sectors including machinery, electronics, textiles, chemicals, and infrastructure project financing",
+      "Loss and compensation data: annual claims paid, loss ratios by country and industry, recovery rates, and compensation trends indicating stress in China's export credit portfolio",
+      "Overseas investment insurance statistics: coverage for Chinese outbound direct investment (ODI) projects by country and industry, including infrastructure, energy, mining, and manufacturing investments",
+      "Enterprise type breakdown: insurance coverage distributed among large SOEs, mid-sized private exporters, SMEs, and cross-border e-commerce enterprises, with policy support metrics for each segment",
+      "Annual report financial data: Sinosure's own financial performance including total assets, underwriting profits, investment income, reserve levels, and solvency ratios as a policy insurance entity"
+    ],
+    "zh": [
+      "出口信用保险承保统计：年度保费收入、出口保险金额和承保出口商数量，按险种（短期险、中长期险、境外投资险）分类，并附历史对比数据",
+      "国家风险评估与分类：中国信保对200余个国家和地区的自有国家风险评级，按政治风险、转移风险和商业风险分类，每年更新",
+      "出口保险承保的地区分布：按目的国和地区分类的承保出口金额，重点突出一带一路沿线国家、非洲市场和新兴经济体的覆盖情况",
+      "行业领域覆盖数据：机械、电子、纺织、化工和基础设施项目融资等主要出口行业的保险渗透率和承保金额",
+      "损失与赔偿数据：年度赔偿金额、按国家和行业的赔付率、追偿率及赔偿趋势，反映中国出口信用组合的压力状况",
+      "境外投资保险统计：中国对外直接投资（ODI）项目按国家和行业的承保情况，含基础设施、能源、矿业和制造业投资",
+      "企业类型分布：大型国有企业、中型民营出口商、中小企业及跨境电商企业的保险覆盖情况，及各细分市场的政策支持指标",
+      "年度报告财务数据：中国信保作为政策性保险机构的自身财务状况，包括总资产、承保利润、投资收益、准备金水平和偿付能力比率"
+    ]
+  }
+}

--- a/firstdata/sources/china/finance/china-cicpa.json
+++ b/firstdata/sources/china/finance/china-cicpa.json
@@ -1,0 +1,72 @@
+{
+  "id": "china-cicpa",
+  "name": {
+    "en": "Chinese Institute of Certified Public Accountants",
+    "zh": "中国注册会计师协会"
+  },
+  "description": {
+    "en": "The Chinese Institute of Certified Public Accountants (CICPA) is the national professional organization and self-regulatory body for the CPA profession in China, operating under the Ministry of Finance. CICPA maintains authoritative registries and statistical databases on China's certified public accountant population, accounting firms, and audit market. It publishes annual reports on the scale and structure of China's accounting profession, market concentration among audit firms, earnings of the Big Four and top domestic firms, and the results of CPA qualification examinations. CICPA data is essential for assessing financial audit quality, auditor independence, and the governance standards of China's listed companies and state-owned enterprises.",
+    "zh": "中国注册会计师协会（中注协）是全国注册会计师行业的全国性专业组织和自律机构，在财政部指导下运行。中注协维护权威的注册会计师执业人员、会计师事务所及审计市场统计数据库，并发布年度报告，涵盖中国会计职业规模与结构、审计市场集中度、四大及国内头部事务所业务收入、注册会计师资格考试结果等信息。中注协数据是评估财务审计质量、审计师独立性以及上市公司和国有企业治理水平的重要依据。"
+  },
+  "website": "https://www.cicpa.org.cn",
+  "data_url": "https://www.cicpa.org.cn/xxcx/",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "finance",
+    "governance",
+    "statistics"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "注册会计师",
+    "certified public accountant",
+    "会计师事务所",
+    "accounting firm",
+    "审计市场",
+    "audit market",
+    "CPA考试",
+    "CPA examination",
+    "财务审计",
+    "financial audit",
+    "四大",
+    "Big Four",
+    "审计质量",
+    "audit quality",
+    "会计行业",
+    "accounting profession",
+    "财政部",
+    "Ministry of Finance",
+    "执业注册",
+    "professional registration",
+    "事务所收入",
+    "firm revenue",
+    "行业统计",
+    "industry statistics",
+    "CICPA"
+  ],
+  "data_content": {
+    "en": [
+      "CPA population statistics: total number of registered CPAs, practicing CPAs, and non-practicing CPAs in China by province and city, with historical growth trends and demographic breakdown by age and gender",
+      "Accounting firm registry and rankings: annual revenue, employee counts, partner numbers, and service structure for the top 100 accounting firms in China, including Big Four, mid-tier, and domestic firms",
+      "Audit market concentration data: market share analysis by firm size, industry sector, and listed company audit assignments, including percentage of A-share, H-share, and SOE audit engagements by firm tier",
+      "CPA qualification examination results: annual pass rates, registration numbers, subject-level performance, and score distributions for China's national CPA examination across provinces",
+      "Professional discipline and enforcement: annual reports on disciplinary actions against firms and individual CPAs, audit failures, regulatory sanctions, and enforcement patterns by the Ministry of Finance and CSRC",
+      "Continuing education compliance: registered CPAs' annual continuing professional education (CPE) completion rates, accredited training programs, and online learning statistics",
+      "International audit standards adoption: data on the adoption of Chinese audit standards aligned with International Standards on Auditing (ISA) and progress in cross-border audit cooperation frameworks",
+      "Firm organizational structure data: number of limited liability partnerships versus general partnerships, branch office networks, and geographic distribution of accounting firms across China's provinces"
+    ],
+    "zh": [
+      "注册会计师人数统计：全国各省市注册会计师总数、执业会计师和非执业会计师数量，含历史增长趋势及按年龄和性别的人口特征分析",
+      "会计师事务所名册与排名：全国百强事务所年度收入、从业人员数量、合伙人人数及业务结构，涵盖四大、中型及本土事务所",
+      "审计市场集中度数据：按事务所规模、行业领域及上市公司审计委托的市场份额分析，包括各层级事务所承接A股、H股及国有企业审计业务的比例",
+      "注册会计师资格考试结果：全国注册会计师考试各省通过率、报名人数、各科目表现及分数分布情况",
+      "职业纪律与执法：财政部和中国证监会对事务所和个人会计师的年度纪律处分、审计失败、监管处罚及执法规律报告",
+      "继续教育合规情况：注册会计师年度继续职业教育（CPE）完成率、认可培训项目及在线学习统计数据",
+      "国际审计准则采用：与国际审计准则（ISA）接轨的中国审计准则采用情况数据及跨境审计合作框架进展",
+      "事务所组织结构数据：有限责任合伙与普通合伙的数量，分支机构网络及会计师事务所在全国各省市的地域分布"
+    ]
+  }
+}

--- a/firstdata/sources/china/finance/china-ncssf.json
+++ b/firstdata/sources/china/finance/china-ncssf.json
@@ -1,0 +1,73 @@
+{
+  "id": "china-ncssf",
+  "name": {
+    "en": "National Council for Social Security Fund",
+    "zh": "全国社会保障基金理事会"
+  },
+  "description": {
+    "en": "The National Council for Social Security Fund (NCSSF) is the state institution responsible for managing China's National Social Security Fund (NSSF), a strategic reserve fund established to support future social security expenditures. NCSSF publishes annual reports detailing fund size, investment portfolio composition, returns, and asset allocation across domestic and overseas markets. With total assets exceeding 3 trillion RMB, NSSF data provides critical insights into China's long-term pension reserves, sovereign wealth allocation strategies, equity and bond market investments, and the sustainability of China's social security system. NCSSF's annual reports are authoritative references for China's retirement security and institutional investment landscape.",
+    "zh": "全国社会保障基金理事会是负责管理全国社会保障基金（社保基金）的国家机构，该基金是为应对未来社会保障支出而设立的战略储备资金。理事会发布年度报告，详述基金规模、投资组合构成、收益情况及境内外市场资产配置。社保基金总资产超过3万亿元人民币，相关数据对深入了解中国长期养老储备、主权财富配置战略、股票和债券市场投资及社会保障制度可持续性具有重要参考价值。理事会年报是研究中国养老保障和机构投资格局的权威依据。"
+  },
+  "website": "https://www.ssf.gov.cn",
+  "data_url": "https://www.ssf.gov.cn/portal/ztzl/ztjy/A002602index_1.htm",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "finance",
+    "economics",
+    "social-policy"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "社保基金",
+    "social security fund",
+    "养老金",
+    "pension reserve",
+    "基金投资",
+    "fund investment",
+    "资产配置",
+    "asset allocation",
+    "投资收益",
+    "investment returns",
+    "社会保障",
+    "social security",
+    "战略储备",
+    "strategic reserve",
+    "机构投资",
+    "institutional investment",
+    "权益投资",
+    "equity investment",
+    "债券投资",
+    "bond investment",
+    "境外投资",
+    "overseas investment",
+    "基金规模",
+    "fund size",
+    "NSSF",
+    "NCSSF"
+  ],
+  "data_content": {
+    "en": [
+      "Annual fund size and total assets: year-end balance of the National Social Security Fund, broken down by fund type (central reserve fund, entrusted provincial pension funds) with historical trend data from 2000 to present",
+      "Investment portfolio and asset allocation: detailed breakdown of equity, fixed income, alternative investments, domestic and overseas assets, with percentage allocations and changes from prior year",
+      "Annual investment returns: fund-level and asset-class-level annual returns, cumulative returns since inception, and comparison with benchmark indices for performance evaluation",
+      "Income and expenditure statements: annual contribution income, investment income, fiscal transfers, and disbursements for social security purposes including central and provincial entrusted fund flows",
+      "Equity holdings and stock market exposure: major equity positions, A-share and overseas stock allocations, industrial equity funds, and private equity investments with valuation changes",
+      "Fixed income securities data: government bond holdings, policy bank bonds, corporate bond positions, and money market fund allocations with maturity profiles",
+      "Overseas investment data: geographic distribution of overseas investments by country and region, overseas equity and fixed income exposures, and foreign currency asset management data",
+      "Entrusted provincial fund management: scale and performance of pension funds entrusted by provinces to NCSSF for professional management, covering contribution rates, beneficiary coverage, and return targets"
+    ],
+    "zh": [
+      "年度基金规模和总资产：全国社会保障基金年末余额，按基金类别（中央储备基金、受托省级养老金）分类，并附2000年至今历史趋势数据",
+      "投资组合和资产配置：股票、固定收益、另类投资、境内外资产的详细分类，包含各类资产占比及较上年变化情况",
+      "年度投资收益：基金整体及各资产类别年度收益率、成立以来累计收益率，以及与基准指数的业绩比较数据",
+      "收入与支出情况：年度缴费收入、投资收入、财政拨款及用于社会保障的拨付情况，含中央和省级受托基金资金流向",
+      "股权持仓和股市敞口：主要权益仓位、A股和境外股票配置、产业股权基金和私募股权投资及估值变化",
+      "固定收益证券数据：国债持仓、政策性银行债、企业债券仓位及货币市场基金配置和期限分布",
+      "境外投资数据：境外投资按国家和地区的地理分布、境外股票和固定收益敞口及外汇资产管理数据",
+      "受托省级基金管理：省级委托全国社保基金理事会专业管理的养老金规模和业绩，包括缴费率、受益人覆盖面和收益目标"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-ngeos.json
+++ b/firstdata/sources/china/research/china-ngeos.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-ngeos",
+  "name": {
+    "en": "National Earth System Science Data Center",
+    "zh": "国家地球系统科学数据中心"
+  },
+  "description": {
+    "en": "The National Earth System Science Data Center (NGEOS) is one of China's 20 national science data centers, hosted by the Institute of Geographic Sciences and Natural Resources Research at the Chinese Academy of Sciences (CAS). NGEOS is the primary national repository for earth system science datasets in China, integrating multidisciplinary data on the atmosphere, hydrosphere, lithosphere, biosphere, and cryosphere. It provides open access to climate, hydrology, ecology, land use, remote sensing, and socioeconomic data for China and the Asia-Pacific region, supporting research on global change, carbon cycles, disaster risk, and sustainable development. NGEOS serves as a hub for sharing field observation data from research stations across China.",
+    "zh": "国家地球系统科学数据中心（NGEOS）是中国20个国家科学数据中心之一，依托中国科学院地理科学与资源研究所建设。该中心是中国地球系统科学数据的主要国家存储库，整合大气圈、水圈、岩石圈、生物圈和冰冻圈多学科数据。开放共享中国及亚太地区气候、水文、生态、土地利用、遥感和社会经济数据，支持全球变化、碳循环、灾害风险和可持续发展研究。中心是汇聚全国各地野外观测站实地观测数据共享的重要平台。"
+  },
+  "website": "https://www.geodata.cn",
+  "data_url": "https://www.geodata.cn/data/",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "environmental-science",
+    "earth-science",
+    "climate"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "地球系统科学",
+    "earth system science",
+    "气候数据",
+    "climate data",
+    "水文数据",
+    "hydrological data",
+    "生态数据",
+    "ecological data",
+    "土地利用",
+    "land use",
+    "遥感数据",
+    "remote sensing data",
+    "碳循环",
+    "carbon cycle",
+    "全球变化",
+    "global change",
+    "冰冻圈",
+    "cryosphere",
+    "中国科学院",
+    "Chinese Academy of Sciences",
+    "野外台站",
+    "field research station",
+    "开放数据",
+    "open data",
+    "资源环境",
+    "resources and environment",
+    "可持续发展",
+    "sustainable development",
+    "NGEOS"
+  ],
+  "data_content": {
+    "en": [
+      "Climate and meteorological datasets: long-term surface temperature, precipitation, wind speed, humidity, and solar radiation records from China's meteorological observation network, including gridded datasets at multiple resolutions from 1951 to present",
+      "Hydrological data: river discharge, groundwater levels, lake area and depth, evapotranspiration, and basin-scale water balance datasets for China's major river systems including Yangtze, Yellow, Pearl, and inland rivers",
+      "Land use and land cover change data: multi-temporal national land use classification at 100m and 1km resolutions from 1980-2020, tracking urbanization, deforestation, wetland loss, and agricultural land changes across China",
+      "Ecological and biodiversity datasets: vegetation coverage (NDVI) time series, species distribution models, forest biomass, grassland productivity, and biodiversity indices for China's major ecosystems",
+      "Cryosphere data: glacier area and volume changes, permafrost distribution and active layer depth, snow cover extent and snow water equivalent from the Qinghai-Tibetan Plateau and high-altitude regions",
+      "Socioeconomic geographic data: spatial datasets on population distribution, GDP per capita by county, poverty mapping, agricultural production zones, and infrastructure accessibility across China",
+      "Carbon flux and greenhouse gas data: ecosystem carbon uptake and release measurements from flux tower networks, soil respiration rates, and methane emissions from wetlands and rice paddies across China",
+      "Remote sensing satellite products: derived Earth observation products from Chinese satellites (FY, HJ, GF series) including land surface temperature, vegetation indices, aerosol optical depth, and soil moisture"
+    ],
+    "zh": [
+      "气候和气象数据集：来自中国气象观测网络的长期地表温度、降水量、风速、湿度和太阳辐射记录，包含1951年至今不同分辨率的格网化数据集",
+      "水文数据：长江、黄河、珠江及内陆河等中国主要流域的河流径流量、地下水位、湖泊面积和深度、蒸散量及流域水量平衡数据集",
+      "土地利用与土地覆盖变化数据：1980—2020年100米和1千米分辨率的全国多时相土地利用分类，追踪全国城镇化、森林减少、湿地消失和农业用地变化",
+      "生态和生物多样性数据集：植被覆盖度（NDVI）时间序列、物种分布模型、森林生物量、草地生产力及中国主要生态系统生物多样性指数",
+      "冰冻圈数据：青藏高原和高海拔地区冰川面积和体积变化、多年冻土分布及活动层深度、积雪范围和雪水当量",
+      "社会经济地理数据：全国人口分布、各县GDP、贫困地图、农业生产区划和基础设施可达性空间数据集",
+      "碳通量和温室气体数据：通量塔网络生态系统碳吸收和释放测量值、土壤呼吸速率及全国湿地和稻田甲烷排放量",
+      "遥感卫星产品：中国卫星（风云、环境、高分系列）衍生的地球观测产品，包括地表温度、植被指数、气溶胶光学厚度和土壤湿度"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/china-ngcc.json
+++ b/firstdata/sources/china/resources/china-ngcc.json
@@ -1,0 +1,74 @@
+{
+  "id": "china-ngcc",
+  "name": {
+    "en": "National Geomatics Center of China",
+    "zh": "国家基础地理信息中心"
+  },
+  "description": {
+    "en": "The National Geomatics Center of China (NGCC) is the primary national agency responsible for surveying, mapping, and maintaining China's national geographic information infrastructure. Under the Ministry of Natural Resources, NGCC manages the National Basic Geographic Database, the most authoritative source of fundamental geographic data in China, including topographic maps, digital elevation models (DEM), satellite imagery, administrative boundaries, and land use data. NGCC provides public access to standardized geographic datasets at multiple scales (1:50,000 to 1:1,000,000) used in urban planning, environmental monitoring, disaster response, infrastructure development, and national census operations. It also coordinates China's geodetic reference systems and national mapping standards.",
+    "zh": "国家基础地理信息中心是负责中国国家地理信息基础设施测绘、制图和维护的主要国家机构，隶属于自然资源部。中心管理国家基础地理信息数据库，是全国最权威的基础地理数据来源，包括地形图、数字高程模型（DEM）、卫星影像、行政区划边界和土地利用数据。中心提供多比例尺（1:5万至1:100万）标准化地理数据集，广泛应用于城市规划、环境监测、灾害救援、基础设施建设和全国人口普查。同时负责协调中国大地测量参考系统和全国测绘标准。"
+  },
+  "website": "https://www.ngcc.cn",
+  "data_url": "https://www.ngcc.cn/dlxxzy/gjjcdlxxsjk/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "geography",
+    "environmental-science",
+    "infrastructure"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "基础地理信息",
+    "basic geographic information",
+    "国家地理数据库",
+    "national geographic database",
+    "数字高程模型",
+    "digital elevation model",
+    "地形图",
+    "topographic map",
+    "行政区划",
+    "administrative boundary",
+    "土地利用",
+    "land use",
+    "地理信息系统",
+    "GIS",
+    "测绘",
+    "surveying and mapping",
+    "卫星影像",
+    "satellite imagery",
+    "国家测绘",
+    "national mapping",
+    "空间数据",
+    "spatial data",
+    "大地测量",
+    "geodesy",
+    "NGCC",
+    "自然资源部",
+    "Ministry of Natural Resources"
+  ],
+  "data_content": {
+    "en": [
+      "National Basic Geographic Database: fundamental geographic datasets at 1:50,000, 1:250,000, and 1:1,000,000 scales including terrain, hydrography, transportation networks, settlements, and administrative boundaries for all of China",
+      "Digital elevation model (DEM) data: national digital terrain models derived from topographic surveys and satellite imagery, providing elevation data at 25m and 90m resolutions for terrain analysis and hydrological modeling",
+      "Administrative boundary data: official authoritative datasets of county-level, prefecture-level, and provincial administrative boundaries with regularly updated polygon and line features for China's 34 provincial-level units",
+      "Satellite and aerial imagery archives: multi-temporal satellite image datasets for China including optical and synthetic aperture radar (SAR) imagery used for land cover classification and change detection",
+      "Land use and land cover data: national land use classification datasets at 1:50,000 scale including cultivated land, forest, grassland, water bodies, built-up areas, and unused land based on remote sensing interpretation",
+      "Geodetic reference network data: China's national coordinate reference system (CGCS2000), gravity network benchmarks, and height datum information supporting precise positioning and engineering surveys",
+      "Urban geographic database: large-scale urban geographic datasets at 1:2,000 and 1:5,000 scales for major cities, including building footprints, road networks, utility infrastructure, and points of interest",
+      "Geographic names database: national standardized database of geographic place names including mountains, rivers, lakes, villages, and administrative areas with official Chinese and romanized designations"
+    ],
+    "zh": [
+      "国家基础地理信息数据库：1:5万、1:25万、1:100万比例尺全国基础地理数据集，包含地形、水系、交通网络、居民地和行政区划要素",
+      "数字高程模型（DEM）数据：基于地形测量和卫星影像生成的全国数字地形模型，提供25米和90米分辨率高程数据，用于地形分析和水文建模",
+      "行政区划数据：县级、地级和省级行政区划的权威官方数据集，含定期更新的34个省级行政单位矢量面和线要素",
+      "卫星和航空影像档案：全国多时相卫星影像数据集，包括光学和合成孔径雷达（SAR）影像，用于土地覆盖分类和变化检测",
+      "土地利用和土地覆盖数据：1:5万比例尺全国土地利用分类数据，基于遥感解译，涵盖耕地、林地、草地、水体、建设用地和未利用地",
+      "大地测量参考网数据：中国国家坐标参考系（CGCS2000）、重力网基准点和高程基准信息，支持精密定位和工程测量",
+      "城市地理数据库：主要城市1:2000和1:5000比例尺大比例尺城市地理数据集，含建筑轮廓、道路网络、公共设施基础设施和兴趣点",
+      "地名数据库：全国标准化地名数据库，包含山脉、河流、湖泊、村庄和行政区的官方中文及罗马化名称"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds **5 Chinese government/institutional data sources** as part of the daily AM batch contribution.

## New Sources

| ID | Name (EN) | Name (ZH) | Website | Category |
|---|---|---|---|---|
| china-ncssf | National Council for Social Security Fund | 全国社会保障基金理事会 | ssf.gov.cn | finance |
| china-cicpa | Chinese Institute of Certified Public Accountants | 中国注册会计师协会 | cicpa.org.cn | finance |
| china-ngcc | National Geomatics Center of China | 国家基础地理信息中心 | ngcc.cn | resources |
| china-sinosure | China Export & Credit Insurance Corporation | 中国出口信用保险公司 | sinosure.com.cn | economy/trade |
| china-ngeos | National Earth System Science Data Center | 国家地球系统科学数据中心 | geodata.cn | research |

## Validation
- ✅ All 5 sources passed blacklist check (no prohibited domains)
- ✅ No duplicate IDs or website URLs
- ✅ `make check` passed (453 total IDs, all unique)
- ✅ All URLs verified accessible
- ✅ Schema compliance confirmed (no `native` field, kebab-case domains)

## Data Coverage
These sources expand FirstData's coverage of:
- **Social security & pension reserves**: NCSSF manages China's 3+ trillion RMB strategic pension fund
- **Professional financial oversight**: CICPA oversees China's 450,000+ CPAs and audit market
- **National geographic infrastructure**: NGCC maintains China's authoritative geographic databases
- **Export credit intelligence**: Sinosure is China's sole policy export credit insurer with country risk ratings
- **Earth system science**: NGEOS provides open access to climate, ecology, and remote sensing datasets