### PR TITLE
feat: add 5 Chinese data sources (PM batch, 2026-04-16)

### DIFF
--- a/firstdata/sources/china/finance/capital-markets/china-chinabond.json
+++ b/firstdata/sources/china/finance/capital-markets/china-chinabond.json
@@ -1,0 +1,68 @@
+{
+  "id": "china-chinabond",
+  "name": {
+    "en": "China Bond Information Network",
+    "zh": "中国债券信息网"
+  },
+  "description": {
+    "en": "China Bond Information Network (Chinabond) is the official information disclosure and data platform operated by China Central Depository & Clearing Co., Ltd. (CCDC), the central securities depository for China's interbank bond market supervised by the People's Bank of China. It serves as the authoritative source for bond yield curves, bond issuance prospectuses, bond market statistics, and credit rating disclosures for the Chinese bond market - the world's second-largest bond market. Chinabond publishes the widely referenced ChinaBond yield curve series covering government bonds, policy bank bonds, corporate bonds, and asset-backed securities, and provides transparency data for all bonds registered in the interbank market.",
+    "zh": "中国债券信息网（Chinabond）是中央国债登记结算有限责任公司（中债登）运营的官方信息披露与数据平台。中债登受中国人民银行监管，是中国银行间债券市场的中央证券托管机构。该平台是中国债券市场（全球第二大债券市场）债券收益率曲线、债券发行说明书、债券市场统计数据及信用评级披露的权威来源。中国债券信息网发布广泛引用的中债收益率曲线系列，涵盖国债、政策性银行债、企业债及资产支持证券，并为银行间市场登记的所有债券提供透明度数据。"
+  },
+  "website": "https://www.chinabond.com.cn",
+  "data_url": "https://yield.chinabond.com.cn/cbweb-pbc-web/pbc/historyQuery",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "finance",
+    "economics"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "债券收益率",
+    "bond yield",
+    "中债收益率曲线",
+    "ChinaBond yield curve",
+    "国债",
+    "government bond",
+    "政策性银行债",
+    "policy bank bond",
+    "企业债",
+    "corporate bond",
+    "资产支持证券",
+    "ABS",
+    "银行间债券市场",
+    "interbank bond market",
+    "债券发行",
+    "bond issuance",
+    "信用评级",
+    "credit rating",
+    "中央国债登记结算",
+    "CCDC",
+    "固定收益",
+    "fixed income",
+    "债券市场统计",
+    "bond market statistics"
+  ],
+  "data_content": {
+    "en": [
+      "ChinaBond yield curves: daily benchmark yield curves for government bonds, policy bank bonds, corporate bonds, and ABS across various maturities",
+      "Bond issuance disclosures: prospectuses, offering documents, and registration materials for all interbank market bonds",
+      "Bond market statistics: monthly and annual data on bond issuance volume, outstanding balance, and market structure",
+      "Credit rating disclosures: rating reports and rating change announcements for rated bonds",
+      "Bond trading and settlement data: interbank market secondary trading statistics",
+      "Asset-backed securities: ABS issuance documents, servicer reports, and trustee disclosures",
+      "Green bond registry: labeled green bond issuance information and use-of-proceeds reports"
+    ],
+    "zh": [
+      "中债收益率曲线：国债、政策性银行债、企业债及资产支持证券各期限的每日基准收益率曲线",
+      "债券发行披露：银行间市场所有债券的募集说明书、发行文件及登记材料",
+      "债券市场统计：债券发行量、存量余额及市场结构的月度和年度数据",
+      "信用评级披露：已评级债券的评级报告及评级变化公告",
+      "债券交易与结算数据：银行间市场二级交易统计",
+      "资产支持证券：ABS发行文件、服务机构报告及受托机构披露",
+      "绿色债券注册：标注绿色债券的发行信息及募集资金用途报告"
+    ]
+  }
+}

--- a/firstdata/sources/china/governance/china-wenshu.json
+++ b/firstdata/sources/china/governance/china-wenshu.json
@@ -1,0 +1,71 @@
+{
+  "id": "china-wenshu",
+  "name": {
+    "en": "China Judgments Online",
+    "zh": "中国裁判文书网"
+  },
+  "description": {
+    "en": "China Judgments Online (Wenshu) is the official public disclosure platform for judicial documents operated by the Supreme People's Court of China. Launched in 2013, it is one of the world's largest databases of court judgments, hosting hundreds of millions of judicial documents from courts at all levels across China — from the Supreme People's Court down to district courts. The platform provides full-text access to civil, criminal, administrative, enforcement, and state compensation rulings, and is a critical resource for legal research, compliance due diligence, litigation analytics, and empirical legal studies. The database reflects China's judicial transparency initiative and is widely used by lawyers, academics, and corporate legal teams to research case precedents, litigation trends, and judicial interpretations.",
+    "zh": "中国裁判文书网是最高人民法院运营的司法文书官方公开平台。该平台于2013年上线，是全球最大的裁判文书数据库之一，收录了从最高人民法院到基层法院各级法院的数亿份司法文书。平台提供民事、刑事、行政、执行及国家赔偿裁判文书的全文访问，是法律研究、合规尽调、诉讼分析及实证法学研究的重要资源。该数据库是中国司法公开改革的重要体现，被律师、学者及企业法务广泛用于研究案例先例、诉讼趋势及司法解释。"
+  },
+  "website": "https://wenshu.court.gov.cn",
+  "data_url": "https://wenshu.court.gov.cn/website/wenshu/181107ANFZ0BXSK4/index.html",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "legal",
+    "governance"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "裁判文书",
+    "court judgment",
+    "司法文书",
+    "judicial document",
+    "最高人民法院",
+    "Supreme People's Court",
+    "民事判决",
+    "civil judgment",
+    "刑事判决",
+    "criminal judgment",
+    "行政诉讼",
+    "administrative litigation",
+    "法律研究",
+    "legal research",
+    "案例数据库",
+    "case database",
+    "司法透明",
+    "judicial transparency",
+    "诉讼分析",
+    "litigation analytics",
+    "合规尽调",
+    "compliance due diligence",
+    "法律科技",
+    "legal tech",
+    "中国法院",
+    "Chinese courts",
+    "审判公开"
+  ],
+  "data_content": {
+    "en": [
+      "Civil judgments: first, second, and retrial instance decisions on civil disputes including contracts, property, family, labor, and corporate matters",
+      "Criminal judgments: rulings in criminal cases at all court levels covering the full range of criminal offenses",
+      "Administrative judgments: decisions in cases where citizens or entities sue government bodies for administrative actions",
+      "Enforcement rulings: court orders and decisions related to the enforcement of judgments",
+      "State compensation rulings: decisions on claims for state compensation for wrongful government acts",
+      "Full-text search: keyword and structured search across hundreds of millions of judicial documents by case type, court level, region, and year",
+      "Judicial statistics: aggregate data on caseload trends, case types, and court-level distribution"
+    ],
+    "zh": [
+      "民事判决：涵盖合同、物权、家事、劳动、公司等事项的一审、二审及再审裁判文书",
+      "刑事判决：各级法院对全部刑事罪名的刑事裁判文书",
+      "行政判决：公民或机构就行政行为起诉政府机关的裁判文书",
+      "执行裁定：与判决执行相关的法院命令及裁定",
+      "国家赔偿裁定：对政府违法行为提出国家赔偿请求的裁定",
+      "全文检索：通过案件类型、法院层级、地区、年份等对数亿份司法文书进行关键词和结构化检索",
+      "司法统计：案件数量趋势、案件类型及法院层级分布的汇总数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-cciee.json
+++ b/firstdata/sources/china/research/china-cciee.json
@@ -1,0 +1,72 @@
+{
+  "id": "china-cciee",
+  "name": {
+    "en": "China Center for International Economic Exchanges",
+    "zh": "中国国际经济交流中心"
+  },
+  "description": {
+    "en": "The China Center for International Economic Exchanges (CCIEE) is a high-level government think tank established in 2009 under the State Council's Development Research Center, led by senior government officials and economists. CCIEE conducts strategic policy research on major international and domestic economic issues, publishes influential research reports on global economic governance, trade policy, the Belt and Road Initiative, financial opening, and China's macroeconomic outlook. It hosts the annual China Development Forum supplement sessions and produces widely cited macroeconomic forecasts and policy recommendations. CCIEE serves as a key advisory body for China's economic policymaking and international economic diplomacy, and its research outputs are used by government agencies, international organizations, and financial institutions.",
+    "zh": "中国国际经济交流中心（CCIEE）是2009年成立的高级别国家智库，隶属于国务院发展研究中心，由资深政府官员和经济学家领导。CCIEE就重大国际和国内经济问题开展战略政策研究，发布全球经济治理、贸易政策、一带一路、金融开放及中国宏观经济展望等方面的权威研究报告。CCIEE主办中国发展论坛配套会议，发布广泛引用的宏观经济预测及政策建议。作为中国经济决策和国际经济外交的重要咨询机构，其研究成果被政府机构、国际组织和金融机构广泛使用。"
+  },
+  "website": "https://www.cciee.org.cn",
+  "data_url": "https://www.cciee.org.cn/ktcglistall.aspx?clmId=650",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "economics",
+    "trade",
+    "finance"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国经济",
+    "China economy",
+    "宏观经济",
+    "macroeconomics",
+    "经济预测",
+    "economic forecast",
+    "全球经济治理",
+    "global economic governance",
+    "贸易政策",
+    "trade policy",
+    "一带一路",
+    "Belt and Road",
+    "BRI",
+    "金融开放",
+    "financial opening",
+    "中国发展论坛",
+    "China Development Forum",
+    "政策研究",
+    "policy research",
+    "国际贸易",
+    "international trade",
+    "人民币国际化",
+    "RMB internationalization",
+    "智库",
+    "think tank",
+    "CCIEE",
+    "国务院智库"
+  ],
+  "data_content": {
+    "en": [
+      "Macroeconomic forecasts: quarterly and annual forecasts for China's GDP growth, inflation, trade balance, and key economic indicators",
+      "Policy research reports: strategic analysis on trade policy, financial regulation, industrial policy, and international economic cooperation",
+      "Belt and Road Initiative research: investment flows, infrastructure project data, and economic impact assessments along BRI corridors",
+      "Global economic governance: analysis of G20, WTO, IMF, and other multilateral economic governance frameworks from a Chinese perspective",
+      "Financial opening research: reports on capital account liberalization, RMB internationalization, and China's financial sector reform",
+      "Blue book publications: annual China economic outlook and strategic economic reports",
+      "Conference proceedings: summaries and keynote content from CCIEE-hosted international economic forums"
+    ],
+    "zh": [
+      "宏观经济预测：中国GDP增长、通货膨胀、贸易差额及主要经济指标的季度和年度预测",
+      "政策研究报告：贸易政策、金融监管、产业政策及国际经济合作战略分析",
+      "一带一路研究：沿线投资流量、基础设施项目数据及经济影响评估",
+      "全球经济治理：从中国视角分析G20、WTO、IMF等多边经济治理框架",
+      "金融开放研究：资本账户自由化、人民币国际化及中国金融部门改革报告",
+      "蓝皮书出版物：年度中国经济展望及战略经济报告",
+      "会议文集：CCIEE主办国际经济论坛的摘要及主旨内容"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-cpdrc.json
+++ b/firstdata/sources/china/research/china-cpdrc.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-cpdrc",
+  "name": {
+    "en": "China Population and Development Research Center",
+    "zh": "中国人口与发展研究中心"
+  },
+  "description": {
+    "en": "The China Population and Development Research Center (CPDRC) is a specialized public research institution under the National Health Commission (NHC) of China, dedicated to research on population dynamics, reproductive health, aging, family planning policy, and the relationship between population and sustainable development. As the principal national think tank for population policy, CPDRC provides data analysis, policy evaluation, and demographic projections that directly inform China's population strategy — including the historic shifts from the one-child policy to the two-child and three-child policies. It publishes research on birth rates, mortality, population aging, migration, gender ratios, and fertility trends, and maintains databases on reproductive health and family planning statistics essential for understanding China's demographic transition.",
+    "zh": "中国人口与发展研究中心（CPDRC）是国家卫生健康委员会（国家卫健委）下属的专业公益性科研机构，专注于人口动态、生育健康、人口老龄化、计划生育政策及人口与可持续发展关系研究。作为国家人口政策的主要智库，CPDRC提供数据分析、政策评估和人口预测，直接为中国人口战略提供决策支撑——包括从独生子女政策向二孩、三孩政策历史性转变的决策。研究中心发布出生率、死亡率、人口老龄化、人口迁移、性别比例和生育趋势等方面的研究成果，并维护生育健康和计划生育统计数据库，对理解中国人口转型至关重要。"
+  },
+  "website": "https://www.cpdrc.org.cn",
+  "data_url": "https://www.cpdrc.org.cn/sjzw/",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "social",
+    "health",
+    "statistics"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "人口研究",
+    "population research",
+    "人口动态",
+    "population dynamics",
+    "生育率",
+    "fertility rate",
+    "出生率",
+    "birth rate",
+    "人口老龄化",
+    "population aging",
+    "计划生育",
+    "family planning",
+    "三孩政策",
+    "three-child policy",
+    "生育健康",
+    "reproductive health",
+    "人口预测",
+    "demographic projection",
+    "人口迁移",
+    "population migration",
+    "人口转型",
+    "demographic transition",
+    "国家卫健委",
+    "NHC",
+    "人口政策",
+    "population policy",
+    "性别比",
+    "sex ratio",
+    "人口统计"
+  ],
+  "data_content": {
+    "en": [
+      "Fertility and birth data: annual birth rates, total fertility rates (TFR), and fertility trends by province and demographic group",
+      "Population aging statistics: elderly population ratios, dependency ratios, aging trends by region, and projections",
+      "Population projections: short- and long-term demographic forecasts for China under different policy scenarios",
+      "Reproductive health data: maternal and child health indicators, contraceptive use rates, and reproductive health service coverage",
+      "Family planning policy evaluation: data-driven assessments of the effects of two-child and three-child policies on birth rates",
+      "Population migration research: inter-provincial migration flows, rural-urban migration patterns, and floating population statistics",
+      "Gender and sex ratio analysis: sex ratio at birth trends, causes, and demographic consequences",
+      "International comparison: China's demographic indicators benchmarked against other countries and global averages"
+    ],
+    "zh": [
+      "生育与出生数据：按省份和人口群体分类的年度出生率、总和生育率及生育趋势",
+      "人口老龄化统计：老年人口比例、抚养比、区域老龄化趋势及预测",
+      "人口预测：不同政策情景下中国人口的中长期预测",
+      "生育健康数据：母婴健康指标、避孕使用率及生育健康服务覆盖率",
+      "计划生育政策评估：基于数据的二孩、三孩政策对出生率影响评估",
+      "人口迁移研究：省际迁移流动、城乡迁移模式及流动人口统计",
+      "性别与性别比分析：出生性别比趋势、成因及人口后果",
+      "国际比较：中国人口指标与其他国家及全球平均水平的比较分析"
+    ]
+  }
+}

--- a/firstdata/sources/china/technology/standards/china-cnis.json
+++ b/firstdata/sources/china/technology/standards/china-cnis.json
@@ -1,0 +1,71 @@
+{
+  "id": "china-cnis",
+  "name": {
+    "en": "China National Institute of Standardization",
+    "zh": "中国标准化研究院"
+  },
+  "description": {
+    "en": "The China National Institute of Standardization (CNIS) is a central public research institution under the State Administration for Market Regulation (SAMR), dedicated to standardization research, standard development, and conformity assessment in China. CNIS serves as a key technical support body for China's national standardization system and participates in international standardization work through ISO and IEC. It conducts applied research on emerging technology standards including artificial intelligence, smart manufacturing, consumer safety, and green/low-carbon standards, and publishes authoritative research reports, standard interpretations, and policy consultations on China's standardization strategy.",
+    "zh": "中国标准化研究院（CNIS）是国家市场监督管理总局（市场监管总局）下属的中央公益性科研机构，专注于标准化研究、标准制定及合格评定工作。CNIS是中国国家标准化体系的重要技术支撑机构，并通过ISO和IEC参与国际标准化工作。研究院开展人工智能、智能制造、消费者安全、绿色低碳等新兴技术领域的应用研究，发布权威研究报告、标准解读及中国标准化战略政策咨询。"
+  },
+  "website": "https://www.cnis.ac.cn",
+  "data_url": "https://www.cnis.ac.cn/kycg/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "technology",
+    "industry",
+    "economics"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "标准化研究",
+    "standardization research",
+    "国家标准",
+    "national standard",
+    "GB标准",
+    "GB standard",
+    "ISO",
+    "IEC",
+    "合格评定",
+    "conformity assessment",
+    "人工智能标准",
+    "AI standards",
+    "智能制造",
+    "smart manufacturing",
+    "消费品安全",
+    "consumer safety",
+    "绿色标准",
+    "green standards",
+    "低碳",
+    "low-carbon",
+    "标准化战略",
+    "standardization strategy",
+    "市场监管",
+    "market regulation",
+    "SAMR",
+    "CNIS"
+  ],
+  "data_content": {
+    "en": [
+      "Standardization research reports: policy research on national and international standardization strategies, technical reports on emerging technology standards",
+      "Standard development data: statistics on national standards (GB) in development, revision, and adoption by sector",
+      "Conformity assessment research: research on testing, inspection, and certification systems aligned with international best practices",
+      "AI and digital standards: technical frameworks and research for artificial intelligence, big data, and smart manufacturing standardization",
+      "Green and low-carbon standards: research outputs supporting China's dual-carbon goals through standardization of energy, emissions, and circular economy",
+      "Consumer product safety: research and standards development for product safety requirements and testing methods",
+      "International standardization: Chinese participation in ISO/IEC technical committees and outcomes of international standard votes"
+    ],
+    "zh": [
+      "标准化研究报告：国内外标准化战略政策研究、新兴技术标准技术报告",
+      "标准制定数据：按行业分类的国家标准（GB）制定、修订和采标统计",
+      "合格评定研究：与国际最佳实践接轨的检测、检验和认证体系研究",
+      "人工智能与数字标准：人工智能、大数据和智能制造标准化技术框架与研究",
+      "绿色低碳标准：支持中国双碳目标的能源、排放及循环经济标准化研究成果",
+      "消费品安全：产品安全要求和测试方法的研究与标准制定",
+      "国际标准化：中国参与ISO/IEC技术委员会情况及国际标准投票结果"
+    ]
+  }
+}


### PR DESCRIPTION
## 📦 本次提交：5个中国数据源（下午批次）

### 新增数据源

| ID | 名称 | 领域 | 权威级别 | 更新频率 |
|---|---|---|---|---|
| china-chinabond | 中国债券信息网 | finance, economics | market | daily |
| china-cnis | 中国标准化研究院 | technology, industry | government | irregular |
| china-cciee | 中国国际经济交流中心 | economics, trade | research | irregular |
| china-wenshu | 中国裁判文书网 | legal, governance | government | daily |
| china-cpdrc | 中国人口与发展研究中心 | social, health, statistics | research | irregular |

### 详细说明

1. **china-chinabond** — 中国债券信息网（chinabond.com.cn）
   - 中央国债登记结算有限责任公司（CCDC）运营，人民银行监管
   - 提供债券收益率曲线、发行披露、市场统计和信用评级数据
   - 全球第二大债券市场的权威数据来源

2. **china-cnis** — 中国标准化研究院（cnis.ac.cn）
   - 市场监管总局下属公益性科研机构
   - 国家标准化体系技术支撑，参与ISO/IEC国际标准制定
   - 涵盖AI、智能制造、绿色低碳等新兴技术标准研究

3. **china-cciee** — 中国国际经济交流中心（cciee.org.cn）
   - 2009年成立的国家级高端智库
   - 宏观经济预测、一带一路、全球经济治理等政策研究
   - 政府机构、国际组织和金融机构的重要参考来源

4. **china-wenshu** — 中国裁判文书网（wenshu.court.gov.cn）
   - 最高人民法院官方司法文书公开平台（2013年）
   - 全球最大裁判文书数据库之一，收录数亿份民事/刑事/行政判决
   - 法律研究、合规尽调、诉讼分析的核心资源

5. **china-cpdrc** — 中国人口与发展研究中心（cpdrc.org.cn）
   - 国家卫健委下属人口政策主要智库
   - 生育率、人口老龄化、人口迁移、性别比等权威数据
   - 支撑中国三孩政策等重大决策的核心研究机构

### 质量检查
- ✅ make check 通过（453个ID均唯一，JSON格式验证通过）
- ✅ 黑名单检查全部通过（5/5无违规）
- ✅ 所有URL curl验证可达（200 OK）
- ✅ 无 native 字段，无下划线 domain
- ✅ 符合 datasource-schema.json v2.0.0