### PR TITLE
feat: add 5 Chinese government data sources (AM batch, 2026-04-17)

### DIFF
--- a/firstdata/sources/china/economy/industry_associations/china-cnea.json
+++ b/firstdata/sources/china/economy/industry_associations/china-cnea.json
@@ -1,0 +1,74 @@
+{
+  "id": "china-cnea",
+  "name": {
+    "en": "China Nuclear Energy Association",
+    "zh": "中国核能行业协会"
+  },
+  "description": {
+    "en": "The China Nuclear Energy Association (CNEA) is the national industry organization representing China's nuclear energy sector, covering nuclear power generation, nuclear fuel cycle, radiation technology, and nuclear equipment manufacturing. China operates the world's largest nuclear power expansion program and is the dominant force in global nuclear construction. CNEA publishes annual reports, monthly operating statistics, and industry development data on nuclear power installed capacity, electricity generation, reactor construction progress, fuel consumption, safety performance, and workforce figures. It also tracks China's nuclear equipment exports, international cooperation, and the development of advanced reactor technologies including Generation III and IV designs. CNEA data is indispensable for energy analysts, investors, and policymakers tracking China's low-carbon energy transition and global nuclear industry trends.",
+    "zh": "中国核能行业协会（CNEA）是代表中国核能行业的全国性行业组织，涵盖核电发电、核燃料循环、辐射技术和核设备制造等领域。中国拥有全球最大规模的核电扩张计划，是全球核电建设的主导力量。中国核能行业协会发布核电装机容量、发电量、反应堆建设进度、燃料消耗、安全业绩及从业人员等年度报告、月度运行统计和行业发展数据，同时追踪中国核设备出口、国际合作及三代、四代反应堆技术研发进展。协会数据是能源分析师、投资者和政策制定者追踪中国低碳能源转型及全球核能行业趋势的重要参考。"
+  },
+  "website": "https://www.china-nea.cn/",
+  "data_url": "https://www.china-nea.cn/",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "energy",
+    "industry",
+    "economics"
+  ],
+  "update_frequency": "monthly",
+  "tags": [
+    "核能",
+    "nuclear energy",
+    "核电",
+    "nuclear power",
+    "核电站",
+    "nuclear power plant",
+    "装机容量",
+    "installed capacity",
+    "发电量",
+    "electricity generation",
+    "反应堆",
+    "reactor",
+    "核燃料",
+    "nuclear fuel",
+    "铀",
+    "uranium",
+    "CNEA",
+    "核安全",
+    "nuclear safety",
+    "碳中和",
+    "carbon neutrality",
+    "清洁能源",
+    "clean energy",
+    "华龙一号",
+    "Hualong One",
+    "核设备",
+    "nuclear equipment"
+  ],
+  "data_content": {
+    "en": [
+      "Nuclear power installed capacity: operational, under-construction, and planned reactor units with MW capacity by plant",
+      "Monthly electricity generation: nuclear power output (TWh) and share of national power mix",
+      "Reactor construction progress: new unit groundbreaking, grid connection milestones, and construction timelines",
+      "Nuclear fuel cycle data: uranium ore production, enrichment capacity, and fuel fabrication volumes",
+      "Safety performance indicators: unplanned shutdowns, radiation exposure, and WANO performance index",
+      "Annual nuclear energy development report: comprehensive sector overview including investment, employment, and technology progress",
+      "Nuclear equipment manufacturing: domestic content ratios, key component production, and export statistics",
+      "Advanced reactor development: status of Gen III+ (Hualong One, CAP1400) and Gen IV (HTR, CFETR) programs"
+    ],
+    "zh": [
+      "核电装机容量：按电站统计的在役、在建及规划机组数量及MW容量",
+      "月度发电量：核电发电量（TWh）及占全国电力结构的比例",
+      "反应堆建设进度：新机组开工、并网里程碑及建设时间进度",
+      "核燃料循环数据：铀矿石产量、浓缩能力和燃料组件制造量",
+      "安全业绩指标：非计划停机次数、辐射剂量和WANO性能指数",
+      "核能年度发展报告：包括投资、从业人员和技术进展的行业综合概述",
+      "核设备制造：国产化率、关键部件产量和出口统计",
+      "先进堆型研发：三代及三代+（华龙一号、CAP1400）和四代堆（高温气冷堆、聚变堆）项目进展"
+    ]
+  }
+}

--- a/firstdata/sources/china/economy/provincial/china-chengdu-stats.json
+++ b/firstdata/sources/china/economy/provincial/china-chengdu-stats.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-chengdu-stats",
+  "name": {
+    "en": "Chengdu Bureau of Statistics",
+    "zh": "成都市统计局"
+  },
+  "description": {
+    "en": "The Chengdu Bureau of Statistics is the official statistical authority for Chengdu, the capital of Sichuan Province and the economic hub of western China. Chengdu is one of China's four first-tier cities by influence and a major center for electronics manufacturing, aerospace, finance, and the digital economy. The bureau publishes comprehensive socioeconomic statistics covering GDP, industrial output, fixed asset investment, retail sales, foreign trade, population, and employment for Chengdu municipality. It releases the Chengdu Statistical Yearbook, monthly economic bulletins, and thematic reports on the city's development as a national center city and New Economy hub in China's western development strategy.",
+    "zh": "成都市统计局是成都市的官方统计机构，成都是四川省省会、中国西部地区经济中心，也是中国新一线城市之一，是电子制造、航空航天、金融和数字经济的重要基地。统计局发布成都市GDP、工业产值、固定资产投资、社会消费品零售总额、对外贸易、人口和就业等全面的社会经济统计数据，出版《成都统计年鉴》、月度经济简报及成都作为国家中心城市、新经济之都和西部大开发重要节点城市的专题报告。"
+  },
+  "website": "http://cdstats.chengdu.gov.cn/",
+  "data_url": "http://cdstats.chengdu.gov.cn/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "subnational",
+  "domains": [
+    "economics",
+    "statistics",
+    "industry",
+    "social"
+  ],
+  "update_frequency": "monthly",
+  "tags": [
+    "成都统计",
+    "Chengdu statistics",
+    "成都GDP",
+    "Chengdu GDP",
+    "西部大开发",
+    "western China development",
+    "四川经济",
+    "Sichuan economy",
+    "成都统计年鉴",
+    "Chengdu Statistical Yearbook",
+    "数字经济",
+    "digital economy",
+    "新经济",
+    "new economy",
+    "电子制造",
+    "electronics manufacturing",
+    "航空航天",
+    "aerospace",
+    "国家中心城市",
+    "national center city",
+    "消费城市",
+    "consumer city",
+    "成都新区",
+    "Chengdu New Area"
+  ],
+  "data_content": {
+    "en": [
+      "GDP and economic growth: quarterly and annual GDP data by industry sector for Chengdu municipality",
+      "Industrial production: output from key industries including electronics, auto parts, food processing, and aerospace",
+      "Digital and new economy: software revenue, digital industry output, and new economy enterprise data",
+      "Fixed asset investment: total investment, real estate development, infrastructure, and industrial projects",
+      "Retail and consumption: total retail sales, consumer price index, and e-commerce data",
+      "Foreign trade and investment: export/import volumes, actually utilized FDI by source country",
+      "Employment and wages: employed persons, urban unemployment rate, and average wages by sector",
+      "Population: resident population, household registration, migration, and urbanization indicators",
+      "Chengdu Statistical Yearbook: comprehensive annual compilation of all municipal statistics across economic and social domains",
+      "Monthly economic briefings: short-term economic performance indicators and trend analysis"
+    ],
+    "zh": [
+      "GDP与经济增长：成都市按产业分类的季度和年度GDP数据",
+      "工业生产：电子、汽车零部件、食品加工和航空航天等重点产业产值",
+      "数字经济与新经济：软件业营业收入、数字产业产值和新经济企业数据",
+      "固定资产投资：全市总投资额、房地产开发、基础设施和工业项目投资",
+      "消费与零售：社会消费品零售总额、居民消费价格指数和电子商务数据",
+      "对外贸易与投资：进出口总额、按来源地统计的实际利用外商直接投资",
+      "就业与工资：从业人员数、城镇登记失业率和各行业平均工资",
+      "人口：常住人口、户籍人口、人口迁移和城镇化指标",
+      "成都统计年鉴：经济和社会各领域全市统计数据综合年度汇编",
+      "月度经济简报：短期经济运行指标和趋势分析"
+    ]
+  }
+}

--- a/firstdata/sources/china/economy/provincial/china-qingdao-stats.json
+++ b/firstdata/sources/china/economy/provincial/china-qingdao-stats.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-qingdao-stats",
+  "name": {
+    "en": "Qingdao Bureau of Statistics",
+    "zh": "青岛市统计局"
+  },
+  "description": {
+    "en": "The Qingdao Bureau of Statistics is the official statistical authority for Qingdao, a coastal metropolis in Shandong Province and one of China's most important port cities. Qingdao is a major hub for maritime trade, advanced manufacturing, marine research, and digital economy, home to major global companies including Haier and Hisense. The bureau publishes comprehensive socioeconomic statistics covering GDP, industrial output, port throughput, foreign trade, fixed asset investment, consumption, population, and employment. It releases the Qingdao Statistical Yearbook and periodic reports on the city's development as a pilot free trade zone and key node in China's maritime economy and Blue Economy strategy.",
+    "zh": "青岛市统计局是青岛市的官方统计机构，青岛是山东省的沿海大城市，是中国重要的港口城市之一，也是海洋贸易、先进制造业、海洋科研和数字经济的重要枢纽，海尔、海信等全球知名企业的总部均设于此。统计局发布青岛市GDP、工业产值、港口吞吐量、对外贸易、固定资产投资、消费、人口和就业等全面的社会经济统计数据，出版《青岛统计年鉴》及青岛作为自由贸易试验区、海洋经济和蓝色经济发展战略重要节点城市的定期报告。"
+  },
+  "website": "http://qdtj.qingdao.gov.cn/",
+  "data_url": "http://qdtj.qingdao.gov.cn/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "subnational",
+  "domains": [
+    "economics",
+    "statistics",
+    "trade",
+    "social"
+  ],
+  "update_frequency": "monthly",
+  "tags": [
+    "青岛统计",
+    "Qingdao statistics",
+    "青岛GDP",
+    "Qingdao GDP",
+    "山东经济",
+    "Shandong economy",
+    "青岛统计年鉴",
+    "Qingdao Statistical Yearbook",
+    "港口",
+    "port",
+    "海洋经济",
+    "marine economy",
+    "蓝色经济",
+    "blue economy",
+    "自由贸易区",
+    "free trade zone",
+    "海尔",
+    "Haier",
+    "先进制造",
+    "advanced manufacturing",
+    "对外贸易",
+    "foreign trade",
+    "港口吞吐量",
+    "port throughput"
+  ],
+  "data_content": {
+    "en": [
+      "GDP and economic growth: quarterly and annual GDP data by industry sector for Qingdao municipality",
+      "Industrial production: output from key industries including home appliances, rail transit equipment, new energy vehicles, and biomedicine",
+      "Port and trade statistics: cargo throughput, container volumes, and foreign trade import/export data",
+      "Marine economy: output value of marine industries, fisheries production, and marine science and technology indicators",
+      "Fixed asset investment: total investment, infrastructure, real estate development, and industrial project data",
+      "Retail and consumption: total retail sales of consumer goods, consumer price index, and e-commerce",
+      "Employment and wages: employed persons, urban unemployment rate, and average wages by sector",
+      "Population: resident population, household registration, and urbanization indicators",
+      "Qingdao Statistical Yearbook: comprehensive annual compilation covering all economic and social statistics",
+      "Free trade zone data: Qingdao Pilot Free Trade Zone economic performance and trade facilitation indicators"
+    ],
+    "zh": [
+      "GDP与经济增长：青岛市按产业分类的季度和年度GDP数据",
+      "工业生产：家电、轨道交通装备、新能源汽车、生物医药等重点产业产值",
+      "港口与贸易统计：货物吞吐量、集装箱量和进出口贸易数据",
+      "海洋经济：海洋产业总产值、渔业生产量和海洋科技指标",
+      "固定资产投资：全市总投资、基础设施、房地产开发和工业项目数据",
+      "消费与零售：社会消费品零售总额、居民消费价格指数和电子商务",
+      "就业与工资：从业人员数、城镇登记失业率和各行业平均工资",
+      "人口：常住人口、户籍人口和城镇化指标",
+      "青岛统计年鉴：涵盖所有经济和社会统计数据的综合年度汇编",
+      "自由贸易区数据：中国（山东）自由贸易试验区青岛片区经济运行及贸易便利化指标"
+    ]
+  }
+}

--- a/firstdata/sources/china/infrastructure/china-crta.json
+++ b/firstdata/sources/china/infrastructure/china-crta.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-crta",
+  "name": {
+    "en": "China Road Transport Association",
+    "zh": "中国道路运输协会"
+  },
+  "description": {
+    "en": "The China Road Transport Association (CRTA) is the national industry organization representing China's road transport sector, including passenger transport, freight logistics, bus and coach services, and road-based supply chain businesses. China operates the world's largest road transport network by volume, and CRTA serves as the authoritative voice for the industry's 30 million-plus practitioners. The association publishes statistical reports on road passenger and freight volumes, vehicle fleet composition, fuel consumption, road safety data, new energy vehicle adoption in transport fleets, and industry revenue. CRTA also tracks emerging trends in logistics digitization, platform economy in transport, and cross-border freight. Its data is essential for supply chain analysts, logistics operators, transport policy researchers, and investors tracking China's vast land-based transport economy.",
+    "zh": "中国道路运输协会（CRTA）是代表中国道路运输行业的全国性行业组织，涵盖旅客运输、货运物流、公路客车及公路供应链等业务。中国拥有全球运量最大的道路运输网络，中国道路运输协会是代表行业3000万余名从业人员的权威机构。协会发布公路客货运量、车辆结构、燃料消耗、道路安全、运输车队新能源汽车普及率及行业营收等统计报告，同时追踪物流数字化、平台经济在运输领域的发展及跨境货运新趋势。其数据对于供应链分析师、物流运营商、交通政策研究人员以及追踪中国陆路运输经济的投资者具有重要参考价值。"
+  },
+  "website": "https://www.crta.org.cn/",
+  "data_url": "https://www.crta.org.cn/news.html?id=42",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "transportation",
+    "logistics",
+    "economics"
+  ],
+  "update_frequency": "monthly",
+  "tags": [
+    "道路运输",
+    "road transport",
+    "货运",
+    "freight transport",
+    "旅客运输",
+    "passenger transport",
+    "物流",
+    "logistics",
+    "运输统计",
+    "transport statistics",
+    "新能源商用车",
+    "new energy commercial vehicles",
+    "公路货运量",
+    "road freight volume",
+    "供应链",
+    "supply chain",
+    "跨境货运",
+    "cross-border freight",
+    "CRTA",
+    "运输平台",
+    "transport platform",
+    "货车",
+    "trucks",
+    "道路安全",
+    "road safety"
+  ],
+  "data_content": {
+    "en": [
+      "Road freight volume: total road freight tonnage and ton-kilometer data at national and regional levels",
+      "Road passenger transport: passenger trips and passenger-kilometer data by service type",
+      "Vehicle fleet statistics: registered commercial vehicle counts by category (trucks, buses, coaches, taxis)",
+      "New energy vehicle adoption: penetration rate of electric and alternative fuel vehicles in road transport fleets",
+      "Industry revenue and operators: total business revenue and count of road transport enterprises",
+      "Fuel consumption and energy: diesel and gasoline consumption by road transport sector",
+      "Road safety data: traffic accident rates, fatalities, and injury statistics for commercial transport",
+      "Cross-border freight: China-Europe land freight volumes, China-ASEAN road cargo data",
+      "Logistics platform economy: data on digital freight matching platforms and transport sharing economy",
+      "Annual industry development report: comprehensive overview of China road transport sector trends and outlook"
+    ],
+    "zh": [
+      "公路货运量：全国及分地区公路货运总量和货物周转量（吨公里）数据",
+      "公路旅客运输：按服务类型分类的旅客出行次数和旅客周转量数据",
+      "车辆结构统计：按类型（货车、公共汽车、长途客车、出租车）统计的营运车辆注册数量",
+      "新能源汽车普及：电动及替代燃料车辆在道路运输车队中的渗透率",
+      "行业营收与经营者：道路运输企业总营业收入和数量",
+      "燃料消耗与能源：道路运输行业柴油和汽油消耗量",
+      "道路安全数据：营运交通的交通事故率、死亡人数和伤亡统计",
+      "跨境货运：中欧陆路货运量、中国—东盟公路货运数据",
+      "物流平台经济：数字货运匹配平台和运输共享经济数据",
+      "年度行业发展报告：中国道路运输行业趋势与展望综合报告"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/environment/china-cace.json
+++ b/firstdata/sources/china/resources/environment/china-cace.json
@@ -1,0 +1,73 @@
+{
+  "id": "china-cace",
+  "name": {
+    "en": "China Association of Circular Economy",
+    "zh": "中国循环经济协会"
+  },
+  "description": {
+    "en": "The China Association of Circular Economy (CACE) is a national industry organization approved by the Ministry of Civil Affairs, evolved from the former China Resources Comprehensive Utilization Association. It represents China's circular economy sector, encompassing recycling, waste resource utilization, urban mining, and low-carbon industrial transformation. CACE publishes annual development reports on circular economy, including data on resource recycling volumes, waste utilization rates, urban mining output, industrial symbiosis, and policy implementation progress. It also releases thematic reports on specific sectors such as waste textiles, electronic waste, and renewable resources. As China pursues carbon neutrality by 2060, CACE's data is essential for tracking progress in circular economy transitions, green manufacturing, and resource efficiency across China's industrial landscape.",
+    "zh": "中国循环经济协会是经民政部批准，由原中国资源综合利用协会更名成立的全国性社团组织，代表中国循环经济行业，涵盖再生资源利用、废物资源化、城市矿产和低碳产业转型等领域。协会发布循环经济年度发展报告，包括再生资源回收量、废物利用率、城市矿产产量、产业共生及政策落实进展等数据，同时发布废旧纺织品、电子废物、再生资源等专题报告。在中国实现2060年碳中和目标的进程中，中国循环经济协会的数据是追踪循环经济转型、绿色制造和工业资源效率进展的重要依据。"
+  },
+  "website": "https://www.chinacace.org/",
+  "data_url": "https://www.chinacace.org/patents/cycle_economy_report/",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "environment",
+    "industry",
+    "economics",
+    "energy"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "循环经济",
+    "circular economy",
+    "再生资源",
+    "renewable resources",
+    "废物利用",
+    "waste utilization",
+    "城市矿产",
+    "urban mining",
+    "碳中和",
+    "carbon neutrality",
+    "绿色制造",
+    "green manufacturing",
+    "资源回收",
+    "resource recycling",
+    "废旧纺织品",
+    "waste textiles",
+    "电子废物",
+    "e-waste",
+    "产业共生",
+    "industrial symbiosis",
+    "CACE",
+    "资源综合利用",
+    "comprehensive resource utilization",
+    "低碳",
+    "low carbon"
+  ],
+  "data_content": {
+    "en": [
+      "China Circular Economy Development Report: annual assessment of national circular economy progress, policy implementation, and key performance indicators",
+      "Resource recycling volumes: statistics on collection and processing of scrap metals, waste paper, plastics, glass, and rubber",
+      "Urban mining output: secondary resource recovery from electronic waste, end-of-life vehicles, and construction demolition",
+      "Waste textile utilization: production, collection, and reuse rates for waste clothing and fiber materials",
+      "Industrial symbiosis data: resource exchange and waste heat utilization within industrial parks",
+      "Circular economy enterprise directory: registered companies engaged in recycling and resource recovery businesses",
+      "Policy tracking reports: implementation of national circular economy promotion laws and five-year plan targets",
+      "Carbon reduction contributions: estimated emissions reductions attributable to circular economy activities"
+    ],
+    "zh": [
+      "中国循环经济发展报告：循环经济国家进展年度评估、政策落实情况及关键绩效指标",
+      "再生资源回收量：废金属、废纸、废塑料、废玻璃和废橡胶的回收和加工统计数据",
+      "城市矿产产量：来自电子废物、报废汽车和建筑拆除的再生资源回收情况",
+      "废旧纺织品利用：废旧服装和纤维材料的产量、回收量和再利用率",
+      "产业共生数据：工业园区内的资源交换和余热利用情况",
+      "循环经济企业名录：从事再生资源回收利用业务的注册企业信息",
+      "政策追踪报告：国家循环经济促进法及五年规划目标的落实进展",
+      "碳减排贡献：循环经济活动带来的温室气体减排量估算"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds 5 new Chinese authoritative data sources for the AM batch (2026-04-17).

## New Sources

| ID | Organization | Type | Website |
|---|---|---|---|
| `china-cace` | 中国循环经济协会 (China Association of Circular Economy) | Industry Association | chinacace.org |
| `china-cnea` | 中国核能行业协会 (China Nuclear Energy Association) | Industry Association | china-nea.cn |
| `china-chengdu-stats` | 成都市统计局 (Chengdu Bureau of Statistics) | Government | cdstats.chengdu.gov.cn |
| `china-qingdao-stats` | 青岛市统计局 (Qingdao Bureau of Statistics) | Government | qdtj.qingdao.gov.cn |
| `china-crta` | 中国道路运输协会 (China Road Transport Association) | Industry Association | crta.org.cn |

## Validation

- ✅ All 5 IDs verified unique (check-candidate.sh)
- ✅ All 5 files pass blacklist check (check-blacklist.sh)
- ✅ All URLs verified reachable (200/301/302/403)
- ✅ `make check` passed (453 unique IDs, valid JSON, consistent domains)
- ✅ No `native` field in name objects
- ✅ Domain fields use lowercase hyphen format
- ✅ All files placed in correct `china/` subdirectories