### PR TITLE
feat: add 5 Chinese research and government data sources (AM batch, 2026-04-19)

### DIFF
--- a/firstdata/sources/china/finance/china-nifd.json
+++ b/firstdata/sources/china/finance/china-nifd.json
@@ -1,0 +1,23 @@
+{
+  "id": "china-nifd",
+  "name": {
+    "en": "National Institution for Finance and Development",
+    "zh": "国家金融与发展实验室"
+  },
+  "description": {
+    "en": "The National Institution for Finance and Development (NIFD) is a national-level research think tank affiliated with the Chinese Academy of Social Sciences, focusing on macroeconomic analysis, financial market research, government debt tracking, and systemic risk assessment.",
+    "zh": "国家金融与发展实验室是中国社会科学院下属的国家级研究智库，专注于宏观经济分析、金融市场研究、政府债务跟踪和系统性风险评估。"
+  },
+  "data_content": {
+    "en": ["macroeconomic analysis reports", "financial market data", "government debt statistics", "systemic risk assessments", "quarterly economic reviews"],
+    "zh": ["宏观经济分析报告", "金融市场数据", "政府债务统计", "系统性风险评估", "季度经济评论"]
+  },
+  "country": "CN",
+  "authority_level": "research",
+  "geographic_scope": "national",
+  "website": "http://www.nifd.cn",
+  "data_url": "http://www.nifd.cn",
+  "domains": ["finance", "economics"],
+  "tags": ["finance", "macroeconomics", "debt", "risk-assessment", "cass", "think-tank"],
+  "update_frequency": "quarterly"
+}

--- a/firstdata/sources/china/research/china-ciecc.json
+++ b/firstdata/sources/china/research/china-ciecc.json
@@ -1,0 +1,23 @@
+{
+  "id": "china-ciecc",
+  "name": {
+    "en": "China International Engineering Consulting Corporation",
+    "zh": "中国国际工程咨询有限公司"
+  },
+  "description": {
+    "en": "The China International Engineering Consulting Corporation (CIECC) is a state-owned consulting firm under the State Council, providing engineering consulting, project evaluation, and policy research services. It publishes investment analysis reports and infrastructure development assessments for national-level projects.",
+    "zh": "中国国际工程咨询有限公司是国务院国资委直属的国有咨询企业，提供工程咨询、项目评估和政策研究服务。发布投资分析报告和国家级项目基础设施发展评估。"
+  },
+  "data_content": {
+    "en": ["infrastructure project evaluations", "investment analysis reports", "engineering consulting data", "policy research publications", "economic feasibility studies"],
+    "zh": ["基础设施项目评估", "投资分析报告", "工程咨询数据", "政策研究出版物", "经济可行性研究"]
+  },
+  "country": "CN",
+  "authority_level": "government",
+  "geographic_scope": "national",
+  "website": "https://www.ciecc.com.cn",
+  "data_url": "https://www.ciecc.com.cn",
+  "domains": ["infrastructure", "economics"],
+  "tags": ["engineering", "consulting", "infrastructure", "investment", "state-council"],
+  "update_frequency": "irregular"
+}

--- a/firstdata/sources/china/research/china-cipd.json
+++ b/firstdata/sources/china/research/china-cipd.json
@@ -1,0 +1,23 @@
+{
+  "id": "china-cipd",
+  "name": {
+    "en": "China Population and Development Research Center",
+    "zh": "中国人口与发展研究中心"
+  },
+  "description": {
+    "en": "The China Population and Development Research Center (CPDRC) is a national-level research institution under the National Health Commission, focusing on population dynamics, demographic trends, family planning evaluation, and population forecasting models for policy support.",
+    "zh": "中国人口与发展研究中心是国家卫健委直属的国家级研究机构，专注于人口动态、人口趋势、计划生育评估和人口预测模型等领域的研究，为政策制定提供支撑。"
+  },
+  "data_content": {
+    "en": ["population statistics", "demographic projections", "fertility surveys", "family planning data", "population development reports"],
+    "zh": ["人口统计数据", "人口预测", "生育调查", "计划生育数据", "人口发展报告"]
+  },
+  "country": "CN",
+  "authority_level": "research",
+  "geographic_scope": "national",
+  "website": "https://www.cpirc.org.cn",
+  "data_url": "https://www.cpirc.org.cn",
+  "domains": ["demographics", "health"],
+  "tags": ["population", "demographics", "fertility", "family-planning", "health-commission"],
+  "update_frequency": "irregular"
+}

--- a/firstdata/sources/china/research/china-cncbd.json
+++ b/firstdata/sources/china/research/china-cncbd.json
@@ -1,0 +1,23 @@
+{
+  "id": "china-cncbd",
+  "name": {
+    "en": "China National Center for Biotechnology Development",
+    "zh": "中国生物技术发展中心"
+  },
+  "description": {
+    "en": "The China National Center for Biotechnology Development (CNCBD) is a public institution under the Ministry of Science and Technology, responsible for biotechnology policy research, project management, and biosafety assessment. It publishes annual biotechnology development reports and manages national key biotech programs.",
+    "zh": "中国生物技术发展中心是科技部直属事业单位，负责生物技术政策研究、项目管理和生物安全评估。发布年度生物技术发展报告，管理国家重点生物技术计划。"
+  },
+  "data_content": {
+    "en": ["biotechnology development reports", "biosafety assessments", "biotech project data", "pharmaceutical R&D statistics", "gene technology policies"],
+    "zh": ["生物技术发展报告", "生物安全评估", "生物技术项目数据", "医药研发统计", "基因技术政策"]
+  },
+  "country": "CN",
+  "authority_level": "government",
+  "geographic_scope": "national",
+  "website": "https://www.cncbd.org.cn",
+  "data_url": "https://www.cncbd.org.cn",
+  "domains": ["science", "health"],
+  "tags": ["biotechnology", "biosafety", "pharmaceutical", "most", "science-policy"],
+  "update_frequency": "annual"
+}

--- a/firstdata/sources/china/research/china-csic.json
+++ b/firstdata/sources/china/research/china-csic.json
@@ -1,0 +1,23 @@
+{
+  "id": "china-csic",
+  "name": {
+    "en": "Institute of Sociology, Chinese Academy of Social Sciences",
+    "zh": "中国社会科学院社会学研究所"
+  },
+  "description": {
+    "en": "The Institute of Sociology at the Chinese Academy of Social Sciences (CASS) is China's leading research institution for sociological studies. It conducts large-scale national surveys and publishes authoritative reports on social stratification, urbanization, family dynamics, and social governance.",
+    "zh": "中国社会科学院社会学研究所是中国社会学研究的核心机构，开展大规模全国性调查并发布社会分层、城镇化、家庭变迁和社会治理等领域的权威报告。"
+  },
+  "data_content": {
+    "en": ["social stratification surveys", "urbanization research data", "family dynamics studies", "social governance reports", "community development data"],
+    "zh": ["社会分层调查", "城镇化研究数据", "家庭变迁研究", "社会治理报告", "社区发展数据"]
+  },
+  "country": "CN",
+  "authority_level": "research",
+  "geographic_scope": "national",
+  "website": "https://sociology.cssn.cn",
+  "data_url": "https://sociology.cssn.cn",
+  "domains": ["social-sciences"],
+  "tags": ["sociology", "social-sciences", "surveys", "urbanization", "cass"],
+  "update_frequency": "irregular"
+}


### PR DESCRIPTION
## 新增 5 个中国数据源（上午批次）

| # | ID | 机构 | 网站 | URL状态 |
|---|---|---|---|---|
| 1 | china-csic | 中国社会科学院社会学研究所 | sociology.cssn.cn | 403 (anti-crawl) ✅ |
| 2 | china-cipd | 中国人口与发展研究中心 | cpirc.org.cn | 301 ✅ |
| 3 | china-nifd | 国家金融与发展实验室 | nifd.cn | 200 ✅ |
| 4 | china-cncbd | 中国生物技术发展中心 | cncbd.org.cn | 200 ✅ |
| 5 | china-ciecc | 中国国际工程咨询有限公司 | ciecc.com.cn | 200 ✅ |

注：cron 原始候选中 china-ier(ie.cas.cn 000) 和 china-ciids(ciids.cn 405) 不可达，已替换为 china-cncbd 和 china-ciecc。

✅ 黑名单检查通过
✅ 重复ID检查通过
✅ Website去重通过
✅ make check 通过

🔴 请勿合并 — 等待明察+明鉴双审