### PR TITLE
fix: update 4 stale URLs with migrated domains (closes #161)

### DIFF
--- a/firstdata/sources/china/economy/provincial/china-ah-stats.json
+++ b/firstdata/sources/china/economy/provincial/china-ah-stats.json
@@ -8,8 +8,8 @@
     "en": "The Anhui Bureau of Statistics is the official statistical authority for Anhui Province, a central-eastern China province experiencing rapid economic transformation driven by emerging industries, high-tech manufacturing, and its integration into the Yangtze River Delta economic region. It publishes comprehensive socioeconomic statistics including GDP, industrial output, agricultural production, population, employment, and consumer prices for Anhui. The bureau releases the Anhui Statistical Yearbook and regular economic bulletins, serving as the authoritative data source for one of China's fastest-growing provincial economies.",
     "zh": "安徽省统计局是安徽省官方统计机构，安徽是中国中东部省份，正经历以新兴产业、高新技术制造业和长三角一体化为驱动的快速经济转型。统计局发布安徽省GDP、工业产值、农业生产、人口、就业和居民消费价格指数等全面的社会经济统计数据，并出版《安徽统计年鉴》及定期经济运行情况报告，是了解中国增速最快省级经济体之一的权威数据来源。"
   },
-  "website": "https://tj.ah.gov.cn/",
-  "data_url": "https://tj.ah.gov.cn/tjyw/tjsj/",
+  "website": "https://tjj.ah.gov.cn",
+  "data_url": "https://tjj.ah.gov.cn/tjsj/",
   "api_url": null,
   "authority_level": "government",
   "country": "CN",

--- a/firstdata/sources/china/economy/provincial/china-nm-stats.json
+++ b/firstdata/sources/china/economy/provincial/china-nm-stats.json
@@ -8,8 +8,8 @@
     "en": "The Inner Mongolia Bureau of Statistics is the official statistical authority for the Inner Mongolia Autonomous Region, China's third largest administrative division and a vast steppe-dominated autonomous region in northern China bordering Russia and Mongolia. Inner Mongolia is China's largest producer of coal, rare earth elements, and cashmere, and a leading region for wind and solar power generation. The bureau publishes comprehensive socioeconomic statistics covering GDP, energy and mineral production, animal husbandry, new energy capacity, population (including Mongolian ethnic minority data), and ecological conservation outcomes. It also releases the Inner Mongolia Statistical Yearbook.",
     "zh": "内蒙古自治区统计局是内蒙古自治区官方统计机构，内蒙古是中国第三大行政区划，是北接俄罗斯和蒙古国的广袤草原自治区。内蒙古是全国最大的煤炭、稀土和羊绒产地，也是风能和太阳能发电的领先地区。统计局发布内蒙古GDP、能源和矿产产量、畜牧业、新能源装机容量、人口（含蒙古族少数民族数据）及生态保护成效等全面社会经济统计，并出版《内蒙古统计年鉴》。"
   },
-  "website": "https://tjj.nmg.gov.cn/",
-  "data_url": "https://tjj.nmg.gov.cn/tjsj/",
+  "website": "http://tj.nmg.gov.cn",
+  "data_url": "http://tj.nmg.gov.cn",
   "api_url": null,
   "authority_level": "government",
   "country": "CN",

--- a/firstdata/sources/china/economy/provincial/china-yn-stats.json
+++ b/firstdata/sources/china/economy/provincial/china-yn-stats.json
@@ -8,8 +8,8 @@
     "en": "The Yunnan Bureau of Statistics is the official statistical authority for Yunnan Province, a biodiversity hotspot and frontier province bordering Myanmar, Laos, and Vietnam. It publishes comprehensive socioeconomic data covering GDP, agricultural production, tourism, mineral resources, cross-border trade, and ethnic minority demographics. Yunnan is strategically important as a gateway to Southeast Asia under China's Belt and Road Initiative and as a major producer of non-ferrous metals, tobacco, and flowers. The bureau releases monthly economic bulletins, the Yunnan Statistical Yearbook, and thematic reports on tourism and ecological development.",
     "zh": "云南省统计局是云南省官方统计机构。云南是生物多样性热点地区，与缅甸、老挝、越南接壤。统计局发布涵盖云南省GDP、农业生产、旅游业、矿产资源、跨境贸易及少数民族人口等全面社会经济数据。云南在「一带一路」框架下战略地位重要，是连接东南亚的重要门户，也是中国有色金属、烟草和鲜花的重要产区。统计局定期发布月度经济运行情况、《云南统计年鉴》及旅游与生态发展专题报告。"
   },
-  "website": "https://tjj.yn.gov.cn/",
-  "data_url": "https://tjj.yn.gov.cn/tjsj/",
+  "website": "http://stats.yn.gov.cn",
+  "data_url": "http://stats.yn.gov.cn",
   "api_url": null,
   "authority_level": "government",
   "country": "CN",

--- a/firstdata/sources/china/governance/china-cnao.json
+++ b/firstdata/sources/china/governance/china-cnao.json
@@ -8,8 +8,8 @@
     "en": "The National Audit Office of China (CNAO) is the supreme audit institution of the People's Republic of China, responsible for auditing the fiscal revenues and expenditures of central government agencies, state-owned enterprises, and financial institutions. It publishes official audit reports, audit findings on government budget execution, special audit investigations, and national audit work reports submitted to the Standing Committee of the National People's Congress. CNAO's disclosures provide unique transparency into public finance, state asset management, and government accountability in China.",
     "zh": "中华人民共和国审计署是中国最高审计机关，负责对中央政府机关、国有企业和金融机构的财政收支进行审计监督。审计署发布官方审计报告、政府预算执行审计结果、专项审计调查报告，以及向全国人民代表大会常务委员会提交的国家审计工作报告。审计署的信息披露为了解中国公共财政、国有资产管理和政府问责提供了独特的透明度视角。"
   },
-  "website": "https://www.cnao.gov.cn/",
-  "data_url": "https://www.cnao.gov.cn/col/col1705/",
+  "website": "https://www.audit.gov.cn",
+  "data_url": "https://www.audit.gov.cn",
   "api_url": null,
   "authority_level": "government",
   "country": "CN",


### PR DESCRIPTION
## Fix

4 个数据源的域名已迁移（DNS NXDOMAIN），更新至新域名。

| 源 | 旧域名 | 新域名 | HTTP |
|---|---|---|---|
| china-cnao | cnao.gov.cn | audit.gov.cn | 301→200 ✅ |
| china-ah-stats | tj.ah.gov.cn | tjj.ah.gov.cn | 403 ✅ |
| china-nm-stats | tjj.nmg.gov.cn | tj.nmg.gov.cn | 403 ✅ |
| china-yn-stats | tjj.yn.gov.cn | stats.yn.gov.cn | 200 ✅ |

Closes #161

🔴 请勿合并 — 等待明察+明鉴双审