### PR TITLE
feat: add 5 China authoritative data sources (AM batch 2026-04-24)

### DIFF
--- a/firstdata/sources/china/economy/market/china-gsxt.json
+++ b/firstdata/sources/china/economy/market/china-gsxt.json
@@ -1,0 +1,46 @@
+{
+  "id": "china-gsxt",
+  "name": {
+    "en": "National Enterprise Credit Information Publicity System",
+    "zh": "国家企业信用信息公示系统"
+  },
+  "description": {
+    "en": "The National Enterprise Credit Information Publicity System (GSXT) is the official government platform operated by the State Administration for Market Regulation (SAMR) of China. It is the authoritative public database for enterprise registration information, credit records, and regulatory compliance data for all enterprises registered in China. The system discloses enterprise basic registration data, annual report filings, administrative penalties, court judgments, business license information, equity structure, and credit ratings. It covers all types of enterprises, individual business entities, and other market entities registered across all provinces and cities in China.",
+    "zh": "国家企业信用信息公示系统（GSXT）是国家市场监督管理总局运营的官方政府平台，是中国境内所有注册企业的工商登记信息、信用记录和监管合规数据的权威公共数据库。系统公示企业基本注册数据、年报信息、行政处罚、法院判决、营业执照信息、股权结构及信用评级，覆盖全国各省市注册的企业、个体工商户及其他市场主体。"
+  },
+  "data_content": {
+    "en": [
+      "enterprise registration and basic information",
+      "annual report filings",
+      "administrative penalty records",
+      "court judgment and enforcement records",
+      "business license and qualification data",
+      "equity structure and shareholder information",
+      "enterprise credit ratings and black lists",
+      "operating status and change history",
+      "branch and subsidiary information",
+      "market entity credit compliance data"
+    ],
+    "zh": [
+      "企业注册与基本信息",
+      "年报信息",
+      "行政处罚记录",
+      "法院判决与执行记录",
+      "营业执照与资质数据",
+      "股权结构与股东信息",
+      "企业信用评级与黑名单",
+      "经营状态与变更历史",
+      "分支机构与子公司信息",
+      "市场主体信用合规数据"
+    ]
+  },
+  "country": "CN",
+  "authority_level": "government",
+  "geographic_scope": "national",
+  "website": "https://www.gsxt.gov.cn",
+  "data_url": "https://www.gsxt.gov.cn",
+  "api_url": null,
+  "domains": ["economy", "governance"],
+  "tags": ["enterprise-credit", "business-registration", "market-supervision", "corporate-data", "credit-system", "企业信用", "工商登记", "市场监管", "信用信息", "营业执照", "股权", "年报", "行政处罚", "SAMR", "市场监管总局", "国家企业信用"],
+  "update_frequency": "daily"
+}

--- a/firstdata/sources/china/resources/water/china-hrc.json
+++ b/firstdata/sources/china/resources/water/china-hrc.json
@@ -1,0 +1,46 @@
+{
+  "id": "china-hrc",
+  "name": {
+    "en": "Huai River Water Resources Commission",
+    "zh": "水利部淮河水利委员会"
+  },
+  "description": {
+    "en": "The Huai River Water Resources Commission (HRC) is a basin-level water authority under the Ministry of Water Resources of China, responsible for the unified governance and management of the Huai River basin. The Huai River basin, located between the Yellow River and the Yangtze River, is one of the most densely populated and agriculturally productive regions in China. The HRC publishes hydrological monitoring data, annual water resources bulletins, flood control statistics, water quality assessments, irrigation water usage data, and basin-wide water allocation records, covering the provinces of Henan, Anhui, Jiangsu, and Shandong.",
+    "zh": "水利部淮河水利委员会（淮委）是水利部直属的流域管理机构，负责淮河流域的统一管理与治理。淮河流域位于黄河与长江之间，是中国人口最稠密、农业最发达的地区之一。淮委发布水文监测数据、年度水资源公报、防汛统计、水质评估、灌溉用水数据及流域水量分配记录，覆盖河南、安徽、江苏、山东等省份。"
+  },
+  "data_content": {
+    "en": [
+      "Huai River basin hydrological monitoring data",
+      "annual water resources bulletins",
+      "flood control and disaster statistics",
+      "water quality assessment reports",
+      "irrigation water usage data",
+      "basin water allocation records",
+      "reservoir and flood detention basin data",
+      "soil and water conservation data",
+      "groundwater monitoring data",
+      "water conservancy infrastructure records"
+    ],
+    "zh": [
+      "淮河流域水文监测数据",
+      "年度水资源公报",
+      "防汛抗灾统计",
+      "水质评估报告",
+      "灌溉用水数据",
+      "流域水量分配记录",
+      "水库与蓄滞洪区数据",
+      "水土保持数据",
+      "地下水监测数据",
+      "水利基础设施记录"
+    ]
+  },
+  "country": "CN",
+  "authority_level": "government",
+  "geographic_scope": "subnational",
+  "website": "http://www.hrc.gov.cn",
+  "data_url": "http://www.hrc.gov.cn",
+  "api_url": null,
+  "domains": ["environment", "infrastructure", "agriculture"],
+  "tags": ["water-resources", "hydrology", "huai-river", "flood", "irrigation", "water-quality", "淮河", "水文", "水资源", "防汛", "灌溉", "流域管理", "水利", "HRC", "淮委", "河南", "安徽", "江苏"],
+  "update_frequency": "irregular"
+}

--- a/firstdata/sources/china/resources/water/china-hwcc.json
+++ b/firstdata/sources/china/resources/water/china-hwcc.json
@@ -1,0 +1,46 @@
+{
+  "id": "china-hwcc",
+  "name": {
+    "en": "Hai River Water Resources Commission",
+    "zh": "水利部海河水利委员会"
+  },
+  "description": {
+    "en": "The Hai River Water Resources Commission (HWCC) is a basin-level water authority under the Ministry of Water Resources of China, responsible for unified governance and management of the Hai River basin, covering the Beijing-Tianjin-Hebei region and surrounding areas. The HWCC publishes hydrological monitoring data, flood and drought statistics, water resources bulletins, water quality assessments, groundwater monitoring, and basin-wide water allocation records. Its data covers the major river systems in the North China Plain including the Yongding River, Daqing River, and Ziya River systems.",
+    "zh": "水利部海河水利委员会（海委）是水利部直属的流域管理机构，负责海河流域的统一管理与治理，覆盖京津冀及周边地区。海委发布水文监测数据、洪涝旱情统计、水资源公报、水质评估、地下水监测及流域水量分配记录，数据涵盖华北平原主要水系，包括永定河、大清河、子牙河水系。"
+  },
+  "data_content": {
+    "en": [
+      "Hai River basin hydrological monitoring data",
+      "annual water resources bulletins",
+      "flood and drought monitoring statistics",
+      "water quality assessment reports",
+      "groundwater monitoring data",
+      "basin water allocation records",
+      "reservoir and dam operation data",
+      "water conservancy project records",
+      "soil and water conservation data",
+      "Beijing-Tianjin-Hebei regional water data"
+    ],
+    "zh": [
+      "海河流域水文监测数据",
+      "年度水资源公报",
+      "洪涝旱情监测统计",
+      "水质评估报告",
+      "地下水监测数据",
+      "流域水量分配记录",
+      "水库大坝调度数据",
+      "水利工程记录",
+      "水土保持数据",
+      "京津冀地区水资源数据"
+    ]
+  },
+  "country": "CN",
+  "authority_level": "government",
+  "geographic_scope": "subnational",
+  "website": "http://www.hwcc.gov.cn",
+  "data_url": "http://www.hwcc.gov.cn",
+  "api_url": null,
+  "domains": ["environment", "infrastructure"],
+  "tags": ["water-resources", "hydrology", "hai-river", "flood", "groundwater", "water-quality", "海河", "水文", "水资源", "防汛", "地下水", "流域管理", "水利", "HWCC", "海委", "京津冀", "华北平原"],
+  "update_frequency": "irregular"
+}

--- a/firstdata/sources/china/resources/water/china-slwr.json
+++ b/firstdata/sources/china/resources/water/china-slwr.json
@@ -1,0 +1,46 @@
+{
+  "id": "china-slwr",
+  "name": {
+    "en": "Songliao River Water Resources Commission",
+    "zh": "水利部松辽水利委员会"
+  },
+  "description": {
+    "en": "The Songliao River Water Resources Commission (SLWRC) is a basin-level water authority under the Ministry of Water Resources of China, responsible for unified governance and management of the Songhua River and Liaohe River basins in Northeast China. The SLWRC publishes hydrological monitoring data, annual water resources bulletins, flood and ice-jam flood statistics, water quality assessments, permafrost hydrology data, and basin-wide water allocation records. Its data covers Northeast China including Heilongjiang, Jilin, Liaoning and Inner Mongolia, featuring unique cold-region hydrology data.",
+    "zh": "水利部松辽水利委员会（松辽委）是水利部直属的流域管理机构，负责松花江流域和辽河流域的统一管理与治理。松辽委发布水文监测数据、年度水资源公报、洪涝冰凌统计、水质评估、冻土水文数据及流域水量分配记录，覆盖黑龙江、吉林、辽宁及内蒙古等东北地区，提供独特的寒区水文数据。"
+  },
+  "data_content": {
+    "en": [
+      "Songhua and Liaohe River basin hydrological data",
+      "annual water resources bulletins",
+      "flood and ice-jam flood statistics",
+      "water quality assessment reports",
+      "cold-region hydrology and permafrost data",
+      "basin water allocation records",
+      "reservoir storage and operation data",
+      "water ecology monitoring data",
+      "groundwater monitoring data",
+      "northeast China regional water data"
+    ],
+    "zh": [
+      "松花江与辽河流域水文数据",
+      "年度水资源公报",
+      "洪涝冰凌统计",
+      "水质评估报告",
+      "寒区水文与冻土数据",
+      "流域水量分配记录",
+      "水库蓄水与调度数据",
+      "水生态监测数据",
+      "地下水监测数据",
+      "东北地区区域水资源数据"
+    ]
+  },
+  "country": "CN",
+  "authority_level": "government",
+  "geographic_scope": "subnational",
+  "website": "http://www.slwr.gov.cn",
+  "data_url": "http://www.slwr.gov.cn/gbjb.jhtml",
+  "api_url": null,
+  "domains": ["environment", "infrastructure"],
+  "tags": ["water-resources", "hydrology", "songhua-river", "liaohe-river", "flood", "ice-jam", "water-quality", "松花江", "辽河", "水文", "水资源", "防汛", "冰凌", "寒区", "流域管理", "水利", "SLWR", "松辽委", "东北"],
+  "update_frequency": "irregular"
+}

--- a/firstdata/sources/china/resources/water/china-yrcc.json
+++ b/firstdata/sources/china/resources/water/china-yrcc.json
@@ -1,0 +1,46 @@
+{
+  "id": "china-yrcc",
+  "name": {
+    "en": "Yellow River Conservancy Commission",
+    "zh": "水利部黄河水利委员会"
+  },
+  "description": {
+    "en": "The Yellow River Conservancy Commission (YRCC) is a basin-level water authority directly under the Ministry of Water Resources of China, responsible for unified management and governance of the Yellow River basin. The YRCC publishes hydrological monitoring data, annual water resources bulletins, flood control reports, sediment transport statistics, water quality assessments, ecological flow data, and basin-wide water allocation records. It maintains official records on Yellow River water levels, flow volumes, reservoir operations, and soil erosion, serving as the authoritative data source for China's second longest river.",
+    "zh": "水利部黄河水利委员会（黄委）是水利部直属的流域管理机构，负责黄河流域的统一管理与治理。黄委发布水文监测数据、年度水资源公报、防汛报告、泥沙输移统计、水质评估、生态流量数据及流域水量分配记录，是黄河水位、流量、水库调度、水土保持的权威数据来源，为中国第二长河提供官方数据服务。"
+  },
+  "data_content": {
+    "en": [
+      "Yellow River hydrological monitoring data",
+      "annual water resources bulletins",
+      "flood control and drought relief statistics",
+      "sediment transport and soil erosion data",
+      "water quality assessment reports",
+      "ecological flow monitoring data",
+      "basin water allocation records",
+      "reservoir storage and operation data",
+      "groundwater monitoring data",
+      "water conservancy project data"
+    ],
+    "zh": [
+      "黄河水文监测数据",
+      "年度水资源公报",
+      "防汛抗旱统计",
+      "泥沙输移与水土流失数据",
+      "水质评估报告",
+      "生态流量监测数据",
+      "流域水量分配记录",
+      "水库蓄水与调度数据",
+      "地下水监测数据",
+      "水利工程数据"
+    ]
+  },
+  "country": "CN",
+  "authority_level": "government",
+  "geographic_scope": "subnational",
+  "website": "http://www.yrcc.gov.cn",
+  "data_url": "http://www.yrcc.gov.cn",
+  "api_url": null,
+  "domains": ["environment", "infrastructure"],
+  "tags": ["water-resources", "hydrology", "yellow-river", "flood", "sediment", "water-quality", "黄河", "水文", "水资源", "防汛", "泥沙", "流域管理", "水利", "YRCC", "黄委", "水库", "生态流量"],
+  "update_frequency": "irregular"
+}


### PR DESCRIPTION
## 本次新增数据源（上午批次·中国优先）

新增 5 个中国权威数据源，以水利流域管理机构为主，补充国家企业信用数据平台。

### 新增列表

| ID | 机构名称 | 网站 | 领域 |
|---|---|---|---|
| `china-yrcc` | 水利部黄河水利委员会 | http://www.yrcc.gov.cn | 水资源·环境 |
| `china-hwcc` | 水利部海河水利委员会 | http://www.hwcc.gov.cn | 水资源·环境 |
| `china-hrc` | 水利部淮河水利委员会 | http://www.hrc.gov.cn | 水资源·环境 |
| `china-slwr` | 水利部松辽水利委员会 | http://www.slwr.gov.cn | 水资源·环境 |
| `china-gsxt` | 国家企业信用信息公示系统 | https://www.gsxt.gov.cn | 经济·治理 |

### 验证情况

- ✅ ID 去重：所有 ID 均未在现有数据库中出现
- ✅ 域名去重：所有域名均未在现有数据库中出现
- ✅ 黑名单检查：全部通过
- ✅ 网站可达性：所有 website 返回 200/301（其中 gsxt 返回 403，符合规则）
- ✅ data_url：深链 404 的已改为 website 根路径
- ✅ `make check`：通过（545 个 ID 唯一）

### 数据源说明

**四大流域委员会**：水利部在全国设立 7 个流域管理机构，本次补充其中 4 个（黄河、海河、淮河、松辽），均为正部级直属单位，掌握各自流域的权威水文、水质、防汛等数据。

**国家企业信用公示系统**：由国家市场监管总局运营，是中国最权威的企业工商注册与信用信息公共数据库，覆盖全国所有类型市场主体。