### PR TITLE
feat: add 5 China authoritative sources (PM batch 2026-04-24)

### DIFF
--- a/firstdata/sources/china/education/china-csdp.json
+++ b/firstdata/sources/china/education/china-csdp.json
@@ -1,0 +1,53 @@
+{
+  "id": "china-csdp",
+  "name": {
+    "en": "China School Development Planning Center",
+    "zh": "教育部学校规划建设发展中心"
+  },
+  "description": {
+    "en": "The China School Development Planning Center (CSDP), under China's Ministry of Education, is responsible for planning, policy research, and development of China's school infrastructure. It publishes data and reports on educational facility construction, school development planning standards, campus sustainability, smart campus initiatives, and education infrastructure investment across the country.",
+    "zh": "教育部学校规划建设发展中心（CSDP）隶属于教育部，负责全国学校基础设施的规划、政策研究与发展工作，发布教育设施建设、学校发展规划标准、校园可持续发展、智慧校园及全国教育基础设施投资等方面的数据与报告。"
+  },
+  "website": "https://www.csdp.edu.cn",
+  "data_url": "https://www.csdp.edu.cn",
+  "api_url": null,
+  "country": "CN",
+  "domains": [
+    "education",
+    "infrastructure",
+    "government"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "annual",
+  "tags": [
+    "china",
+    "education",
+    "school planning",
+    "education infrastructure",
+    "教育部",
+    "学校规划建设",
+    "教育设施",
+    "智慧校园",
+    "校园建设",
+    "教育基础设施"
+  ],
+  "data_content": {
+    "en": [
+      "School Construction Statistics - Data on new school construction, renovation, and facility upgrades nationwide",
+      "Campus Planning Standards - National standards for school infrastructure and space planning",
+      "Smart Campus Initiative - Progress reports on digital transformation in Chinese schools",
+      "Education Infrastructure Investment - Annual investment data in school facilities by province",
+      "Sustainability Reports - Green campus construction and energy-saving benchmarks",
+      "Research Reports - Policy research on school development planning and quality standards"
+    ],
+    "zh": [
+      "学校建设统计 - 全国新建、改建及设施升级数据",
+      "校园规划标准 - 学校基础设施与空间规划国家标准",
+      "智慧校园建设 - 中国学校数字化转型进展报告",
+      "教育基础设施投资 - 各省学校设施年度投资数据",
+      "可持续发展报告 - 绿色校园建设与节能标准",
+      "研究报告 - 学校发展规划与质量标准政策研究"
+    ]
+  },
+  "authority_level": "government"
+}

--- a/firstdata/sources/china/education/china-csdp.json
+++ b/firstdata/sources/china/education/china-csdp.json
@@ -22,14 +22,8 @@
   "tags": [
     "china",
     "education",
-    "school planning",
-    "education infrastructure",
-    "教育部",
-    "学校规划建设",
-    "教育设施",
-    "智慧校园",
-    "校园建设",
-    "教育基础设施"
+    "school-planning",
+    "education-infrastructure"
   ],
   "data_content": {
     "en": [

--- a/firstdata/sources/china/health/china-cacm.json
+++ b/firstdata/sources/china/health/china-cacm.json
@@ -1,0 +1,52 @@
+{
+  "id": "china-cacm",
+  "name": {
+    "en": "Chinese Association of Chinese Medicine",
+    "zh": "中华中医药学会"
+  },
+  "description": {
+    "en": "The Chinese Association of Chinese Medicine (CACM) is China's largest national academic organization in the field of traditional Chinese medicine (TCM). Founded in 1979, it publishes clinical guidelines, TCM research standards, disease classification standards, academic journals, and annual reports on the development of traditional Chinese medicine in China.",
+    "zh": "中华中医药学会（CACM）是中国最大的中医药全国性学术团体，成立于1979年。发布中医药临床指南、研究标准、疾病分类标准、学术期刊及中国中医药事业发展年度报告。"
+  },
+  "website": "https://www.cacm.org.cn",
+  "data_url": "https://www.cacm.org.cn",
+  "api_url": null,
+  "country": "CN",
+  "domains": [
+    "health",
+    "research",
+    "social"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "annual",
+  "tags": [
+    "china",
+    "tcm",
+    "traditional chinese medicine",
+    "中医药",
+    "中华中医药学会",
+    "中医临床指南",
+    "中医研究",
+    "中医标准",
+    "学术团体"
+  ],
+  "data_content": {
+    "en": [
+      "TCM Clinical Guidelines - Evidence-based guidelines for traditional Chinese medicine treatments",
+      "TCM Research Standards - Methodological standards for TCM clinical research",
+      "Disease Classification - TCM-specific disease nomenclature and classification standards",
+      "Annual Development Report - Statistical overview of TCM industry, hospitals, and practitioners",
+      "Academic Journals - Peer-reviewed publications on TCM clinical practice and research",
+      "TCM Education Statistics - Data on TCM universities, graduates, and training programs"
+    ],
+    "zh": [
+      "中医临床指南 - 中医药治疗方案的循证指南",
+      "中医科研标准 - 中医临床研究方法学标准",
+      "疾病分类标准 - 中医特有疾病命名与分类标准",
+      "年度发展报告 - 中医药行业、医院及从业人员统计概况",
+      "学术期刊 - 中医药临床实践与研究同行评审出版物",
+      "中医教育统计 - 中医院校、毕业生及培训项目数据"
+    ]
+  },
+  "authority_level": "research"
+}

--- a/firstdata/sources/china/health/china-cacm.json
+++ b/firstdata/sources/china/health/china-cacm.json
@@ -22,13 +22,7 @@
   "tags": [
     "china",
     "tcm",
-    "traditional chinese medicine",
-    "中医药",
-    "中华中医药学会",
-    "中医临床指南",
-    "中医研究",
-    "中医标准",
-    "学术团体"
+    "traditional-chinese-medicine"
   ],
   "data_content": {
     "en": [

--- a/firstdata/sources/china/industry/china-ceeia.json
+++ b/firstdata/sources/china/industry/china-ceeia.json
@@ -21,16 +21,9 @@
   "update_frequency": "monthly",
   "tags": [
     "china",
-    "electrical equipment",
+    "electrical-equipment",
     "manufacturing",
-    "power equipment",
-    "中国电器工业协会",
-    "电器工业",
-    "发电设备",
-    "输配电",
-    "工业电机",
-    "节能产品",
-    "家用电器"
+    "power-equipment"
   ],
   "data_content": {
     "en": [

--- a/firstdata/sources/china/industry/china-ceeia.json
+++ b/firstdata/sources/china/industry/china-ceeia.json
@@ -1,0 +1,54 @@
+{
+  "id": "china-ceeia",
+  "name": {
+    "en": "China Electrical Equipment Industry Association",
+    "zh": "中国电器工业协会"
+  },
+  "description": {
+    "en": "The China Electrical Equipment Industry Association (CEEIA) is the national industry organization representing China's electrical equipment manufacturing sector. It publishes comprehensive industry statistics, market analysis reports, production data, export figures, and policy recommendations covering power generation equipment, transmission equipment, industrial motors, household appliances, and energy-efficient products.",
+    "zh": "中国电器工业协会（CEEIA）是代表中国电器制造行业的全国性行业组织，发布涵盖发电设备、输配电设备、工业电机、家用电器及节能产品的行业统计数据、市场分析报告、产量数据、出口数据及政策建议。"
+  },
+  "website": "https://www.ceeia.com",
+  "data_url": "https://www.ceeia.com",
+  "api_url": null,
+  "country": "CN",
+  "domains": [
+    "industry",
+    "energy",
+    "manufacturing"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "china",
+    "electrical equipment",
+    "manufacturing",
+    "power equipment",
+    "中国电器工业协会",
+    "电器工业",
+    "发电设备",
+    "输配电",
+    "工业电机",
+    "节能产品",
+    "家用电器"
+  ],
+  "data_content": {
+    "en": [
+      "Electrical Equipment Production Statistics - Monthly and annual output data for major electrical product categories",
+      "Industry Market Analysis - Market size, growth trends, and competitive landscape reports",
+      "Export Data - Electrical equipment export volumes and destination markets",
+      "Energy-Efficiency Standards - Industry benchmarks and compliance data for energy-efficient products",
+      "Power Generation Equipment - Statistics on turbines, generators, and transformer production",
+      "Industry Development Report - Annual overview of China's electrical equipment industry performance"
+    ],
+    "zh": [
+      "电器产品产量统计 - 主要电器品类月度和年度产量数据",
+      "行业市场分析 - 市场规模、增长趋势及竞争格局报告",
+      "出口数据 - 电器设备出口量及目标市场统计",
+      "能效标准 - 节能产品行业基准及合规数据",
+      "发电设备统计 - 汽轮机、发电机及变压器产量数据",
+      "行业发展报告 - 中国电器工业年度发展情况综述"
+    ]
+  },
+  "authority_level": "commercial"
+}

--- a/firstdata/sources/china/national/china-cncaprc.json
+++ b/firstdata/sources/china/national/china-cncaprc.json
@@ -1,0 +1,56 @@
+{
+  "id": "china-cncaprc",
+  "name": {
+    "en": "China National Committee on Ageing",
+    "zh": "中国老龄协会"
+  },
+  "description": {
+    "en": "The China National Committee on Ageing (CNCAPRC), also known as China Association of Gerontology and Geriatrics, is the government-affiliated national organization overseeing ageing affairs in China. It publishes authoritative data on China's ageing population including demographic statistics, elderly care services, pension coverage, health status of older adults, and policy research on population ageing.",
+    "zh": "中国老龄协会（CNCAPRC）是负责中国老龄事业管理的政府关联全国性组织，发布中国老龄人口权威数据，包括人口统计数据、养老服务、养老金覆盖情况、老年人健康状况及人口老龄化政策研究报告。"
+  },
+  "website": "https://www.cncaprc.gov.cn",
+  "data_url": "https://www.cncaprc.gov.cn",
+  "api_url": null,
+  "country": "CN",
+  "domains": [
+    "demographics",
+    "health",
+    "social",
+    "government"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "annual",
+  "tags": [
+    "china",
+    "ageing",
+    "elderly",
+    "demographics",
+    "pension",
+    "中国老龄协会",
+    "老龄化",
+    "养老服务",
+    "老年人口",
+    "人口统计",
+    "养老金",
+    "老年健康"
+  ],
+  "data_content": {
+    "en": [
+      "Ageing Population Statistics - Comprehensive data on China's elderly population size, growth, and distribution",
+      "Elderly Care Services - Data on nursing homes, community care facilities, and home care coverage",
+      "Pension System Coverage - Statistics on urban and rural pension enrollment and benefit levels",
+      "Health Status of Older Adults - Chronic disease prevalence, disability rates, and mental health data",
+      "Ageing Policy Research - Reports on social security reform, long-term care insurance, and ageing in place",
+      "China Report on Ageing - Annual flagship report on the state of China's ageing population"
+    ],
+    "zh": [
+      "老龄人口统计 - 中国老年人口规模、增长及分布综合数据",
+      "养老服务数据 - 养老院、社区养老设施及居家养老覆盖情况",
+      "养老金体系覆盖 - 城乡养老保险参保及待遇水平统计",
+      "老年人健康状况 - 慢性病患病率、残疾率及心理健康数据",
+      "老龄政策研究 - 社会保障改革、长期护理保险及居家养老报告",
+      "中国老龄事业发展报告 - 中国老龄人口状况年度旗舰报告"
+    ]
+  },
+  "authority_level": "government"
+}

--- a/firstdata/sources/china/national/china-cncaprc.json
+++ b/firstdata/sources/china/national/china-cncaprc.json
@@ -25,14 +25,7 @@
     "ageing",
     "elderly",
     "demographics",
-    "pension",
-    "中国老龄协会",
-    "老龄化",
-    "养老服务",
-    "老年人口",
-    "人口统计",
-    "养老金",
-    "老年健康"
+    "pension"
   ],
   "data_content": {
     "en": [

--- a/firstdata/sources/china/resources/china-caea.json
+++ b/firstdata/sources/china/resources/china-caea.json
@@ -22,15 +22,8 @@
   "tags": [
     "china",
     "nuclear",
-    "atomic energy",
-    "nuclear power",
-    "国家原子能机构",
-    "核能",
-    "核电",
-    "原子能",
-    "核安全",
-    "核工业",
-    "铀资源"
+    "atomic-energy",
+    "nuclear-power"
   ],
   "data_content": {
     "en": [

--- a/firstdata/sources/china/resources/china-caea.json
+++ b/firstdata/sources/china/resources/china-caea.json
@@ -1,0 +1,54 @@
+{
+  "id": "china-caea",
+  "name": {
+    "en": "China National Nuclear Safety Administration",
+    "zh": "国家原子能机构"
+  },
+  "description": {
+    "en": "The China National Nuclear Safety Administration (CAEA), known as the National Atomic Energy Agency, is the government authority responsible for managing China's nuclear energy and atomic energy affairs. It publishes official data on nuclear power generation, radioactive materials management, nuclear safety inspections, uranium resources, and China's nuclear industry development.",
+    "zh": "国家原子能机构（CAEA）是负责管理中国核能与原子能事务的政府主管部门，发布核电发电量、放射性材料管理、核安全监察、铀资源及中国核工业发展等方面的权威数据。"
+  },
+  "website": "https://www.caea.gov.cn",
+  "data_url": "https://www.caea.gov.cn",
+  "api_url": null,
+  "country": "CN",
+  "domains": [
+    "energy",
+    "environment",
+    "industry"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "annual",
+  "tags": [
+    "china",
+    "nuclear",
+    "atomic energy",
+    "nuclear power",
+    "国家原子能机构",
+    "核能",
+    "核电",
+    "原子能",
+    "核安全",
+    "核工业",
+    "铀资源"
+  ],
+  "data_content": {
+    "en": [
+      "Nuclear Power Generation - Annual electricity output from China's nuclear power plants",
+      "Nuclear Reactors - Status and capacity data for operational and under-construction reactors",
+      "Uranium Resources - Domestic uranium exploration, mining, and reserves data",
+      "Nuclear Safety Reports - Annual safety inspection results and incident reports",
+      "Radioactive Waste Management - Statistics on radioactive material classification and disposal",
+      "Nuclear Industry Development - China's nuclear technology exports and international cooperation"
+    ],
+    "zh": [
+      "核电发电量 - 中国核电站年度发电量统计",
+      "核反应堆 - 在运及在建反应堆状态与容量数据",
+      "铀资源 - 国内铀矿勘探、开采及储量数据",
+      "核安全报告 - 年度安全监察结果及事件报告",
+      "放射性废物管理 - 放射性材料分类与处置统计",
+      "核工业发展 - 中国核技术出口及国际合作情况"
+    ]
+  },
+  "authority_level": "government"
+}


### PR DESCRIPTION
## 新增5个中国权威数据源（下午批次）

### 数据源列表

| ID | 机构名称 | 领域 | 级别 |
|---|---|---|---|
| china-cacm | 中华中医药学会 | health/research | research |
| china-caea | 国家原子能机构 | energy/environment | government |
| china-csdp | 教育部学校规划建设发展中心 | education/infrastructure | government |
| china-ceeia | 中国电器工业协会 | industry/manufacturing | commercial |
| china-cncaprc | 中国老龄协会 | demographics/health | government |

### 验证情况
- ✅ ID去重检查通过（双重校验）
- ✅ 网站域名去重检查通过
- ✅ 黑名单检查通过
- ✅ website URL访问验证通过（200/301/302）
- ✅ 网站title与机构名一致（已验证）
- ✅ `make check` 验证通过（545个数据源，全部唯一）
- ✅ data_url使用有效路径或根路径

### 覆盖领域
中医药学术研究 | 核能行业 | 教育基础设施 | 电器制造工业 | 老龄化人口统计