### PR TITLE
feat: add 5 China authoritative data sources (PM batch 2026-04-25)

### DIFF
--- a/firstdata/sources/china/economy/industry_associations/china-cppia.json
+++ b/firstdata/sources/china/economy/industry_associations/china-cppia.json
@@ -1,0 +1,66 @@
+{
+  "id": "china-cppia",
+  "name": {
+    "en": "China Plastics Processing Industry Association",
+    "zh": "中国塑料加工工业协会"
+  },
+  "description": {
+    "en": "The China Plastics Processing Industry Association (CPPIA) is the national industry organization representing China's plastics processing sector. It covers manufacturers of plastic products, packaging materials, pipes, films, profiles, and engineering plastics. CPPIA publishes authoritative industry statistics, operational reports, market analysis, and technical standards covering the full plastics processing value chain including production output, consumption, imports/exports, and enterprise performance.",
+    "zh": "中国塑料加工工业协会（CPPIA）是代表中国塑料加工行业的全国性行业组织，成员涵盖塑料制品、包装材料、管材、薄膜、型材、工程塑料等制造企业。协会发布权威的行业统计数据、运行报告、市场分析和技术标准，内容涵盖塑料加工全产业链，包括产量、消费量、进出口及企业经营状况。"
+  },
+  "website": "http://www.cppia.com.cn",
+  "data_url": "http://www.cppia.com.cn",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "manufacturing",
+    "industry",
+    "plastics",
+    "materials"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "塑料",
+    "plastics",
+    "塑料加工",
+    "plastics processing",
+    "塑料制品",
+    "plastic products",
+    "包装材料",
+    "packaging materials",
+    "工程塑料",
+    "engineering plastics",
+    "行业统计",
+    "industry statistics",
+    "产量",
+    "production output",
+    "进出口",
+    "imports exports",
+    "CPPIA",
+    "中国塑料"
+  ],
+  "data_content": {
+    "en": [
+      "Annual plastics processing industry operational statistics: total output, production volume by product category",
+      "Plastics consumption data: domestic demand breakdown by end-use sector (packaging, construction, automotive, agriculture)",
+      "Import and export statistics: plastic raw materials and finished products trade volume and value",
+      "Enterprise performance: revenue, profit margin, employment data across plastics processing sub-sectors",
+      "Market price indices: key plastic resin and product prices (PE, PP, PVC, PET)",
+      "Industry concentration and enterprise scale distribution data",
+      "Technical standards and quality certifications for plastics products",
+      "Annual China Plastics Industry Development Report: comprehensive industry trend analysis"
+    ],
+    "zh": [
+      "塑料加工行业年度运行统计：总产量及按产品类别的生产量",
+      "塑料消费数据：按终端用途（包装、建筑、汽车、农业）分类的国内需求",
+      "进出口统计：塑料原料及制品的贸易量和贸易额",
+      "企业经营数据：塑料加工各细分行业的收入、利润率、就业情况",
+      "市场价格指数：主要塑料树脂和制品价格（PE、PP、PVC、PET）",
+      "行业集中度及企业规模分布数据",
+      "塑料制品技术标准与质量认证",
+      "中国塑料工业发展年度报告：全面的行业趋势分析"
+    ]
+  }
+}

--- a/firstdata/sources/china/economy/industry_associations/china-furniture-association.json
+++ b/firstdata/sources/china/economy/industry_associations/china-furniture-association.json
@@ -1,0 +1,64 @@
+{
+  "id": "china-furniture-association",
+  "name": {
+    "en": "China National Furniture Association",
+    "zh": "中国家具协会"
+  },
+  "description": {
+    "en": "The China National Furniture Association (CNFA) is the national industry organization representing China's furniture manufacturing sector, covering residential furniture, office furniture, kitchen furniture, outdoor furniture, and related components. CNFA publishes industry statistics, market reports, trade data, and standards covering production output, domestic market sales, export performance, material consumption, and enterprise operations in China's furniture industry.",
+    "zh": "中国家具协会（CNFA）是代表中国家具制造业的全国性行业组织，涵盖住宅家具、办公家具、厨房家具、户外家具及相关零部件。协会发布行业统计数据、市场报告、贸易数据和标准，内容涵盖中国家具行业的产量、国内市场销售、出口表现、原材料消费及企业运营情况。"
+  },
+  "website": "https://www.cnfa.com.cn",
+  "data_url": "https://www.cnfa.com.cn",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "manufacturing",
+    "industry",
+    "consumer-goods",
+    "trade"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "家具",
+    "furniture",
+    "家具制造",
+    "furniture manufacturing",
+    "住宅家具",
+    "residential furniture",
+    "办公家具",
+    "office furniture",
+    "厨房家具",
+    "kitchen furniture",
+    "家具出口",
+    "furniture export",
+    "行业统计",
+    "industry statistics",
+    "CNFA",
+    "中国家具"
+  ],
+  "data_content": {
+    "en": [
+      "Annual furniture industry economic operation report: total output value, revenue and profit",
+      "Production statistics: furniture output by category (residential, office, kitchen, outdoor furniture)",
+      "Export performance: furniture export volume and value by product type, destination country, and province",
+      "Import data: imported furniture products volume, value, and source countries",
+      "Domestic market sales: retail sales of furniture by channel and region",
+      "Enterprise data: number of manufacturers, employment, fixed asset investment by scale",
+      "Material consumption: wood, metal, fabric, and other raw material usage statistics",
+      "Furniture quality standards and certification data"
+    ],
+    "zh": [
+      "家具行业经济运行年度报告：总产值、收入及利润",
+      "生产统计：按类别（住宅、办公、厨房、户外家具）的家具产量",
+      "出口表现：按产品类型、目的地国家和省份的家具出口量和出口额",
+      "进口数据：进口家具产品的数量、金额及来源国",
+      "国内市场销售：按渠道和地区的家具零售销售数据",
+      "企业数据：按规模分类的制造商数量、就业人数、固定资产投资",
+      "原材料消耗：木材、金属、布料及其他原材料用量统计",
+      "家具质量标准和认证数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/economy/industry_associations/china-light-industry-council.json
+++ b/firstdata/sources/china/economy/industry_associations/china-light-industry-council.json
@@ -1,0 +1,66 @@
+{
+  "id": "china-light-industry-council",
+  "name": {
+    "en": "China National Light Industry Council",
+    "zh": "中国轻工业联合会"
+  },
+  "description": {
+    "en": "The China National Light Industry Council (CNLIC) is the national federation representing China's light industry sector, encompassing food processing, beverages, household appliances, leather goods, paper, ceramics, clocks, bicycles, sewing machines, and other consumer goods manufacturing industries. CNLIC publishes authoritative industry statistics, development reports, economic analyses, and policy recommendations covering production, sales, exports, and enterprise operations across China's light industry.",
+    "zh": "中国轻工业联合会是代表中国轻工行业的全国性联合组织，涵盖食品加工、饮料、家用电器、皮革制品、造纸、陶瓷、钟表、自行车、缝纫机等消费品制造行业。联合会发布权威的行业统计数据、发展报告、经济分析和政策建议，内容涵盖中国轻工业的生产、销售、出口及企业运营情况。"
+  },
+  "website": "http://www.cnlic.org.cn",
+  "data_url": "http://www.cnlic.org.cn",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "manufacturing",
+    "industry",
+    "consumer-goods",
+    "trade"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "轻工业",
+    "light industry",
+    "消费品",
+    "consumer goods",
+    "食品加工",
+    "food processing",
+    "家用电器",
+    "household appliances",
+    "皮革",
+    "leather",
+    "造纸",
+    "paper",
+    "陶瓷",
+    "ceramics",
+    "行业统计",
+    "industry statistics",
+    "CNLIC",
+    "中国轻工"
+  ],
+  "data_content": {
+    "en": [
+      "Annual light industry economic operation report: total output value, revenue and profit by sub-sector",
+      "Production statistics: output data for major light industry product categories (food, beverages, appliances, leather, paper)",
+      "Export data: light industry products trade volume and value broken down by product type and destination",
+      "Enterprise data: number of enterprises, employment, investment in fixed assets across light industry sectors",
+      "Market concentration and leading enterprise performance analysis",
+      "Import substitution and export competitiveness analysis for key light industry products",
+      "Light industry development plans and policy research reports",
+      "Industry standards and quality data for consumer products"
+    ],
+    "zh": [
+      "轻工业经济运行年度报告：总产值、各细分行业收入及利润",
+      "生产统计：主要轻工产品类别（食品、饮料、电器、皮革、纸张）产量数据",
+      "出口数据：按产品类型和目的地细分的轻工产品贸易量和贸易额",
+      "企业数据：轻工各行业企业数量、就业人数、固定资产投资",
+      "市场集中度及龙头企业经营状况分析",
+      "主要轻工产品进口替代和出口竞争力分析",
+      "轻工业发展规划和政策研究报告",
+      "消费品行业标准和质量数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/economy/industry_associations/china-tea-marketing-association.json
+++ b/firstdata/sources/china/economy/industry_associations/china-tea-marketing-association.json
@@ -1,0 +1,69 @@
+{
+  "id": "china-tea-marketing-association",
+  "name": {
+    "en": "China Tea Marketing Association",
+    "zh": "中国茶叶流通协会"
+  },
+  "description": {
+    "en": "The China Tea Marketing Association (CTMA), also known as 中国茶叶流通协会 or 中茶协, is the national industry organization representing China's tea production, processing, and marketing sector. As the world's largest tea producer and exporter, China's tea industry statistics published by CTMA are key references for agricultural economics, commodity trade, and consumer market analysis. CTMA provides authoritative data on tea production, market prices, trade volumes, quality standards, and enterprise operations across China's major tea-producing regions.",
+    "zh": "中国茶叶流通协会（CTMA，又称中茶协）是代表中国茶叶生产、加工和流通行业的全国性行业组织。作为全球最大的茶叶生产国和出口国，中国茶叶流通协会发布的行业统计数据是农业经济、大宗商品贸易和消费市场分析的重要参考依据。协会提供权威的茶叶产量、市场价格、贸易量、质量标准及企业运营数据，覆盖中国各大茶叶产区。"
+  },
+  "website": "https://www.ctma.com.cn",
+  "data_url": "https://www.ctma.com.cn",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "agriculture",
+    "food-beverage",
+    "trade",
+    "industry"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "茶叶",
+    "tea",
+    "茶叶市场",
+    "tea market",
+    "茶叶产量",
+    "tea production",
+    "茶叶出口",
+    "tea export",
+    "茶叶价格",
+    "tea price",
+    "绿茶",
+    "green tea",
+    "红茶",
+    "black tea",
+    "普洱茶",
+    "pu-erh tea",
+    "茶产业",
+    "tea industry",
+    "CTMA",
+    "中茶协",
+    "中国茶叶流通"
+  ],
+  "data_content": {
+    "en": [
+      "Annual tea production statistics: total output by tea type (green tea, black tea, oolong, white tea, pu-erh) and by province",
+      "Tea market price indices: wholesale and retail prices for major tea varieties by producing region",
+      "Export data: tea export volume and value broken down by type, destination country, and province",
+      "Import statistics: imported tea product volume, value, and source countries",
+      "Domestic consumption data: per capita tea consumption, retail channel distribution, urban vs rural",
+      "Tea enterprise performance: revenue, employment, and market share of major tea companies",
+      "Tea quality and safety standards: pesticide residue testing, grading standards, certification data",
+      "Annual China Tea Industry Development Report: comprehensive production, trade, and market trend analysis"
+    ],
+    "zh": [
+      "茶叶年度产量统计：按茶类（绿茶、红茶、乌龙茶、白茶、普洱茶）和省份的总产量",
+      "茶叶市场价格指数：各主产区主要茶叶品种批发和零售价格",
+      "出口数据：按茶类、目的地国家和省份分类的茶叶出口量和出口额",
+      "进口统计：进口茶叶产品的数量、金额及来源国",
+      "国内消费数据：人均茶叶消费量、零售渠道分布、城乡对比",
+      "茶叶企业经营：主要茶企收入、就业和市场份额",
+      "茶叶质量和安全标准：农药残留检测、等级标准、认证数据",
+      "中国茶叶产业发展年度报告：全面的生产、贸易和市场趋势分析"
+    ]
+  }
+}

--- a/firstdata/sources/china/infrastructure/china-highway-society.json
+++ b/firstdata/sources/china/infrastructure/china-highway-society.json
@@ -1,0 +1,66 @@
+{
+  "id": "china-highway-society",
+  "name": {
+    "en": "China Highway and Transportation Society",
+    "zh": "中国公路学会"
+  },
+  "description": {
+    "en": "The China Highway and Transportation Society (CHTS) is a national academic and professional organization for China's highway and transportation sector, affiliated with the Ministry of Transport. CHTS publishes research reports, technical standards, and data covering highway construction, road infrastructure, traffic volume, transportation technology, and highway safety. It is a key reference for policy research, engineering standards, and transportation planning in China.",
+    "zh": "中国公路学会（CHTS）是中国公路与交通运输行业的全国性学术和专业组织，隶属于交通运输部。学会发布研究报告、技术标准和数据，内容涵盖公路建设、道路基础设施、交通流量、交通运输技术和公路安全。是中国政策研究、工程标准和交通规划的重要参考来源。"
+  },
+  "website": "https://www.chts.cn",
+  "data_url": "https://www.chts.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "infrastructure",
+    "transportation",
+    "construction",
+    "technology"
+  ],
+  "update_frequency": "annual",
+  "tags": [
+    "公路",
+    "highway",
+    "交通运输",
+    "transportation",
+    "道路建设",
+    "road construction",
+    "交通流量",
+    "traffic volume",
+    "公路安全",
+    "highway safety",
+    "交通工程",
+    "traffic engineering",
+    "路网",
+    "road network",
+    "技术标准",
+    "technical standards",
+    "CHTS",
+    "中国公路"
+  ],
+  "data_content": {
+    "en": [
+      "Highway mileage statistics: total road network length by grade (expressway, national highway, provincial highway, rural road)",
+      "Highway construction investment: annual investment data in road infrastructure by region and project type",
+      "Traffic volume data: vehicle counts, passenger and freight transport volume on major highway corridors",
+      "Highway safety statistics: accident frequency, fatality rates, major incident analysis by road type",
+      "Bridge and tunnel statistics: number, length, and structural condition of highway bridges and tunnels",
+      "Technical research reports: pavement technology, bridge engineering, tunnel construction innovations",
+      "Highway freight transport: cargo volume and turnover by transport mode and highway grade",
+      "Transportation planning and policy research reports for China's road network"
+    ],
+    "zh": [
+      "公路里程统计：按等级（高速公路、国道、省道、农村公路）的公路网总里程",
+      "公路建设投资：按地区和项目类型的道路基础设施年度投资数据",
+      "交通流量数据：主要公路走廊的车辆计数、客运和货运量",
+      "公路安全统计：按道路类型分类的事故频率、死亡率和重大事故分析",
+      "桥梁和隧道统计：公路桥梁和隧道的数量、长度和结构状况",
+      "技术研究报告：路面技术、桥梁工程、隧道建设创新",
+      "公路货运：按运输方式和公路等级的货运量和货运周转量",
+      "中国公路网交通规划和政策研究报告"
+    ]
+  }
+}


### PR DESCRIPTION
## 新增数据源 (下午批次)

本次新增 5 个中国权威数据源，均为行业协会/学术机构：

| ID | 机构名称 | 类型 | 网站 |
|---|---|---|---|
| china-cppia | 中国塑料加工工业协会 | market | cppia.com.cn |
| china-light-industry-council | 中国轻工业联合会 | market | cnlic.org.cn |
| china-furniture-association | 中国家具协会 | market | cnfa.com.cn |
| china-tea-marketing-association | 中国茶叶流通协会 | market | ctma.com.cn |
| china-highway-society | 中国公路学会 | research | chts.cn |

## 验证清单
- [x] ID 去重检查（无冲突）
- [x] 网站域名去重检查（无冲突）
- [x] 黑名单检查（全部通过）
- [x] Website URL 可达性验证（200/301/302/403）
- [x] 网站 title 与机构名吻合
- [x] `make check` 验证通过（545 个 ID 唯一，域名一致性通过）
- [x] 一个候选（coalchina.org.cn）因黑名单拦截已替换