### PR TITLE
feat: add 5 Chinese authoritative data sources (AM batch 2026-04-26)

### DIFF
--- a/firstdata/sources/china/finance/banking/china-pbccrc.json
+++ b/firstdata/sources/china/finance/banking/china-pbccrc.json
@@ -1,0 +1,73 @@
+{
+  "id": "china-pbccrc",
+  "name": {
+    "en": "People's Bank of China Credit Reference Center",
+    "zh": "中国人民银行征信中心"
+  },
+  "description": {
+    "en": "The Credit Reference Center (CRC) of the People's Bank of China is the operator of China's national credit registry system—one of the world's largest credit databases. Established in 2006, CRC maintains credit records for over 1.1 billion natural persons and more than 60 million enterprises and other legal entities. It collects credit information from banks, non-bank financial institutions, public utilities, and government agencies, and provides credit reports to lenders, individuals, and authorized institutions for lending decisions, due diligence, and financial supervision. CRC also publishes aggregate credit statistics, reports on the scale of social financing, and research on credit system development that inform monetary policy and financial regulation.",
+    "zh": "中国人民银行征信中心是全国征信系统的运营机构，是全球最大的信用数据库之一。中心成立于2006年，维护着超过11亿自然人和6000万余家企业及其他法人主体的信用记录。数据来源包括银行、非银行金融机构、公用事业单位和政府部门，为贷款机构、个人和授权机构提供信用报告，用于授信决策、尽职调查和金融监管。征信中心还发布信用统计汇总数据、社会融资规模报告和征信体系发展研究，为货币政策和金融监管提供支撑。"
+  },
+  "website": "https://www.pbccrc.org.cn",
+  "data_url": "https://www.pbccrc.org.cn",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "finance",
+    "credit",
+    "banking",
+    "economics"
+  ],
+  "update_frequency": "monthly",
+  "tags": [
+    "人民银行征信",
+    "征信中心",
+    "CRC",
+    "credit reference",
+    "credit bureau",
+    "信用报告",
+    "credit report",
+    "企业信用",
+    "enterprise credit",
+    "个人信用",
+    "personal credit",
+    "社会征信",
+    "social credit",
+    "金融监管",
+    "financial regulation",
+    "银行信贷",
+    "bank lending",
+    "不良贷款",
+    "non-performing loans",
+    "社会融资规模",
+    "aggregate social financing",
+    "征信体系",
+    "credit system",
+    "贷款",
+    "loan",
+    "债务",
+    "debt",
+    "人民银行",
+    "PBC"
+  ],
+  "data_content": {
+    "en": [
+      "Individual Credit Reports: Personal credit history including loans, credit cards, repayment records, and public record information for over 1.1 billion individuals",
+      "Enterprise Credit Reports: Corporate credit histories including business loans, bonds, guarantees, and legal judgment records for 60+ million entities",
+      "Credit Statistics: Aggregate national statistics on credit scale, loan types, overdue rates, and financial system credit quality",
+      "Social Financing Scale: Monthly data on aggregate social financing (TSF), covering bank loans, corporate bonds, equity financing, and off-balance-sheet instruments",
+      "Credit System Research: Annual reports on China's credit system development, coverage rates, and comparative international analyses",
+      "Financial Institution Data: Credit registry data from thousands of banks and licensed non-bank financial institutions across China"
+    ],
+    "zh": [
+      "个人信用报告：超过11亿自然人的贷款、信用卡、还款记录和公共记录信息",
+      "企业信用报告：6000万余家企业的贷款、债券、担保和法院判决记录",
+      "信贷统计：全国信贷规模、贷款类型、逾期率和金融体系信贷质量汇总数据",
+      "社会融资规模：银行贷款、企业债券、股权融资及表外业务的社会融资规模月度数据",
+      "征信研究：中国征信体系发展、覆盖率及国际比较分析年报",
+      "金融机构数据：来自全国数千家银行和持牌非银行金融机构的征信数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/national/meteorology/china-nmic.json
+++ b/firstdata/sources/china/national/meteorology/china-nmic.json
@@ -1,0 +1,80 @@
+{
+  "id": "china-nmic",
+  "name": {
+    "en": "National Meteorological Information Center",
+    "zh": "国家气象信息中心"
+  },
+  "description": {
+    "en": "The National Meteorological Information Center (NMIC), operating under the China Meteorological Administration, is China's primary hub for meteorological data collection, processing, archiving, and distribution. Its public platform, the China Meteorological Data Service Centre (data.cma.cn), provides open and authorized access to decades of surface observations, upper-air soundings, satellite products, radar mosaics, ocean-atmosphere data, and climate reanalysis datasets. Researchers, government agencies, and enterprises can register for tiered data access ranging from free public datasets to professional-grade high-resolution archives. NMIC maintains the National Basic Meteorological Dataset, which records over 2,400 national stations and more than 60,000 automatic weather stations. The center also hosts agrometeorological, marine meteorological, and global exchange datasets from WMO partner nations.",
+    "zh": "国家气象信息中心是中国气象局下属专业机构，负责全国气象数据的采集、加工、存档和分发。其公众服务平台——中国气象数据网（data.cma.cn）提供从免费公开数据到专业级高分辨率档案的分级开放访问。数据内容涵盖数十年地面观测、高空探测、卫星产品、雷达拼图、海气观测和气候再分析数据集。国家基本气象数据集记录了全国2400余个国家站和6万余个自动气象站的观测数据。中心还托管农业气象、海洋气象及世界气象组织成员国交换数据集，是中国气象科研和业务的核心数据枢纽。"
+  },
+  "website": "https://data.cma.cn",
+  "data_url": "https://data.cma.cn/data/index.html",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "meteorology",
+    "climate",
+    "environment",
+    "agriculture",
+    "earth-science"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "国家气象信息中心",
+    "NMIC",
+    "中国气象数据网",
+    "weather data",
+    "meteorology",
+    "climate data",
+    "气象数据",
+    "天气",
+    "气候",
+    "地面观测",
+    "surface observation",
+    "高空探测",
+    "upper-air sounding",
+    "卫星数据",
+    "satellite data",
+    "雷达",
+    "radar",
+    "再分析",
+    "reanalysis",
+    "农业气象",
+    "agrometeorological",
+    "自动气象站",
+    "automatic weather station",
+    "气候变化",
+    "climate change",
+    "降水",
+    "precipitation",
+    "温度",
+    "temperature",
+    "风速",
+    "wind"
+  ],
+  "data_content": {
+    "en": [
+      "Surface Observations: Temperature, precipitation, humidity, wind, pressure, and visibility from 2,400+ national stations and 60,000+ automatic weather stations",
+      "Upper-Air Soundings: Radiosonde profiles of temperature, humidity, and wind at pressure levels from the global upper-air network",
+      "Satellite Products: FY-series meteorological satellite imagery including cloud products, precipitation estimation, land surface temperature, and sea surface temperature",
+      "Radar Mosaics: Nationwide composite weather radar reflectivity and doppler wind products",
+      "Climate Reanalysis: Long-term atmospheric reanalysis datasets for climate research and model validation",
+      "Ocean-Atmosphere Data: Marine meteorological observations including sea surface parameters and wave data",
+      "Agrometeorological Data: Crop phenology, soil moisture, growing degree days, and agricultural weather indices",
+      "Global Exchange Data: Meteorological datasets received from WMO Global Telecommunication System partner countries"
+    ],
+    "zh": [
+      "地面观测：全国2400余个国家站和6万余个自动气象站的温度、降水、湿度、风速、气压、能见度数据",
+      "高空探测：探空仪测量各气压层的温度、湿度和风场廓线",
+      "卫星产品：风云系列气象卫星云产品、降水估算、地表温度和海面温度",
+      "雷达拼图：全国天气雷达反射率合成图及多普勒风场产品",
+      "气候再分析：供气候研究和模型验证的长期大气再分析数据集",
+      "海洋气象：海面气象观测、海浪等海气界面参数",
+      "农业气象：作物物候、土壤水分、积温和农业天气指数",
+      "全球交换数据：通过世界气象组织全球电信系统接收的各国气象数据集"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-cstr.json
+++ b/firstdata/sources/china/research/china-cstr.json
@@ -1,0 +1,80 @@
+{
+  "id": "china-cstr",
+  "name": {
+    "en": "China Science & Technology Resource Identifier Platform",
+    "zh": "科技资源标识服务平台"
+  },
+  "description": {
+    "en": "The China Science and Technology Resource Identifier (CSTR) Platform is China's national persistent identifier system for scientific data resources, operated by the National Science and Technology Infrastructure Center (NSTIC) under the Ministry of Science and Technology. Analogous to DOIs for publications, CSTR assigns permanent, resolvable identifiers to scientific datasets, instruments, specimens, and other research resources managed by China's major scientific data centers. The platform serves as the authoritative registry and resolution service for scientific resources from institutions including the Chinese Academy of Sciences, national key laboratories, and data centers under the National Science and Technology Basic Conditions Platform. Through CSTR, users can discover, cite, and access standardized scientific data across disciplines such as earth sciences, life sciences, materials, astronomy, and social sciences.",
+    "zh": "科技资源标识服务平台（CSTR）是中国科技部国家科技基础条件平台中心运营的国家级科学数据资源持久标识体系。类似于学术出版物的DOI，CSTR为中国主要科学数据中心管理的数据集、仪器设备、标本和其他研究资源分配永久可解析标识符。平台作为科学院、国家重点实验室和国家科技基础条件平台下属数据中心科学资源的权威注册和解析服务，支持跨地球科学、生命科学、材料科学、天文学和社会科学等领域的科学数据发现、引用和访问。"
+  },
+  "website": "https://cstr.cn",
+  "data_url": "https://cstr.cn/resreg",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "science",
+    "earth-science",
+    "biology",
+    "materials",
+    "astronomy"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "科技资源标识",
+    "CSTR",
+    "科学数据",
+    "scientific data",
+    "数据标识",
+    "data identifier",
+    "持久标识",
+    "persistent identifier",
+    "DOI",
+    "科学数据中心",
+    "scientific data center",
+    "国家科技基础条件平台",
+    "national science infrastructure",
+    "中国科学院",
+    "Chinese Academy of Sciences",
+    "地球科学",
+    "earth science",
+    "生命科学",
+    "life science",
+    "材料科学",
+    "materials science",
+    "天文学",
+    "astronomy",
+    "数据共享",
+    "data sharing",
+    "科研数据管理",
+    "research data management",
+    "开放科学",
+    "open science",
+    "数据仓库",
+    "data repository"
+  ],
+  "data_content": {
+    "en": [
+      "Scientific Dataset Registry: Persistent identifiers linking to datasets from China's national scientific data centers across all major disciplines",
+      "Earth and Environment Data: Geoscience, climate, ecology, and environmental observation datasets from CAS institutes and national observatories",
+      "Life Science Data: Biological specimen collections, genomics, biodiversity, and biomedical research datasets",
+      "Materials Science Data: Crystallography, materials properties, and experimental materials datasets from national labs",
+      "Astronomy and Space Data: Observational astronomy data, space science mission products, and cosmological datasets",
+      "Social Science Data: Survey and census data from social science research centers and population studies institutes",
+      "Instrument and Facility Registry: Records of major scientific instruments and facilities available to the research community",
+      "Cross-domain Discovery: Unified search and citation system for all CSTR-identified resources across participating data centers"
+    ],
+    "zh": [
+      "科学数据集注册：链接至中国各主要学科国家科学数据中心数据集的持久标识符",
+      "地球与环境数据：来自中科院研究所和国家观测站的地球科学、气候、生态和环境观测数据集",
+      "生命科学数据：生物标本馆藏、基因组学、生物多样性和生物医学研究数据集",
+      "材料科学数据：来自国家实验室的晶体学、材料性质和实验材料数据集",
+      "天文与空间数据：天文观测数据、航天任务产品和宇宙学数据集",
+      "社会科学数据：社会科学研究中心和人口研究所的调查和普查数据",
+      "仪器设备注册：向科研界开放的大型科学仪器和设施信息",
+      "跨领域发现：面向各参与数据中心所有CSTR标识资源的统一检索和引用系统"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-pku-opendata.json
+++ b/firstdata/sources/china/research/china-pku-opendata.json
@@ -1,0 +1,77 @@
+{
+  "id": "china-pku-opendata",
+  "name": {
+    "en": "Peking University Open Research Data Platform",
+    "zh": "北京大学开放研究数据平台"
+  },
+  "description": {
+    "en": "The Peking University Open Research Data Platform (PKU Open Data) is China's first comprehensive institutional open research data repository, built on the Harvard Dataverse framework and launched by Peking University Library. The platform enables PKU researchers and affiliated institutions to deposit, share, and cite research datasets across all disciplines, including social sciences, economics, public health, environmental studies, humanities, and natural sciences. Datasets are assigned DOI identifiers and linked to published papers, promoting reproducibility and open science. PKU Open Data hosts unique surveys, longitudinal studies, and experimental datasets from one of China's leading universities, making primary research data accessible to the global scholarly community.",
+    "zh": "北京大学开放研究数据平台是中国第一个综合性机构开放研究数据库，由北京大学图书馆依托哈佛大学Dataverse框架建立。平台支持北大研究人员及附属机构在社会科学、经济学、公共卫生、环境研究、人文学科和自然科学等各领域的数据集存档、共享和引用。数据集被分配DOI标识符并与发表论文关联，推动可重复研究和开放科学。平台托管了来自中国顶尖高校的独特调查、纵向研究和实验数据集，向全球学术界开放原始研究数据。"
+  },
+  "website": "https://opendata.pku.edu.cn",
+  "data_url": "https://opendata.pku.edu.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "social",
+    "economics",
+    "health",
+    "environment",
+    "science"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "北京大学",
+    "Peking University",
+    "PKU",
+    "开放数据",
+    "open data",
+    "研究数据",
+    "research data",
+    "数据仓库",
+    "data repository",
+    "Dataverse",
+    "社会科学数据",
+    "social science data",
+    "调查数据",
+    "survey data",
+    "纵向研究",
+    "longitudinal study",
+    "DOI",
+    "开放科学",
+    "open science",
+    "可重复研究",
+    "reproducibility",
+    "经济数据",
+    "economic data",
+    "公共卫生",
+    "public health",
+    "环境数据",
+    "environmental data",
+    "中国学术",
+    "Chinese academia",
+    "北大图书馆"
+  ],
+  "data_content": {
+    "en": [
+      "Social Science Datasets: Surveys, experiments, and longitudinal studies on Chinese society, demographics, labor markets, and social behavior",
+      "Economic Research Data: Firm-level datasets, economic experiments, trade data, and financial market studies from PKU economics research",
+      "Public Health Data: Epidemiological surveys, clinical study datasets, and population health monitoring data",
+      "Environmental Science Data: Ecological observations, pollution monitoring, and environmental impact assessment datasets",
+      "Humanities and Cultural Data: Historical records, digital humanities datasets, and cultural heritage documentation",
+      "Natural Sciences Data: Experimental datasets from physics, chemistry, biology, and materials science research",
+      "Multidisciplinary Survey Data: Cross-disciplinary surveys on topics such as education, poverty, inequality, and governance in China"
+    ],
+    "zh": [
+      "社会科学数据集：关于中国社会、人口、劳动力市场和社会行为的调查、实验和纵向研究",
+      "经济研究数据：来自北大经济学研究的企业级数据集、经济实验、贸易数据和金融市场研究",
+      "公共卫生数据：流行病学调查、临床研究数据集和人口健康监测数据",
+      "环境科学数据：生态观测、污染监测和环境影响评估数据集",
+      "人文与文化数据：历史档案、数字人文数据集和文化遗产记录",
+      "自然科学数据：物理、化学、生物和材料科学研究实验数据集",
+      "多学科调查数据：涵盖中国教育、贫困、不平等和治理等主题的跨学科调查"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/environment/china-ipe.json
+++ b/firstdata/sources/china/resources/environment/china-ipe.json
@@ -1,0 +1,81 @@
+{
+  "id": "china-ipe",
+  "name": {
+    "en": "Institute of Public & Environmental Affairs",
+    "zh": "公众环境研究中心"
+  },
+  "description": {
+    "en": "The Institute of Public & Environmental Affairs (IPE) is a leading Chinese environmental NGO founded in 2006. It operates China's most comprehensive open environmental data platform, aggregating and visualizing government-sourced pollution records, emission data, and compliance information across air, water, soil, radiation, and climate domains. IPE's flagship products include the Blue Map (污染地图) pollution database, the Green Supply Chain CITI Index for supplier environmental performance, and the Corporate Climate Action Index. IPE collects data from the Ministry of Ecology and Environment, local environmental agencies, and listed companies' environmental disclosures to create interactive maps, provincial carbon indexes, and supply chain environmental risk ratings used by multinational corporations, investors, and policymakers worldwide.",
+    "zh": "公众环境研究中心（IPE）成立于2006年，是中国领先的环保非政府组织，运营着中国最全面的开放环境数据平台。该平台整合并可视化来自政府的污染记录、排放数据和合规信息，覆盖大气、水体、土壤、辐射和气候等领域。主要产品包括蔚蓝地图污染数据库、供应链CITI指数（企业环境信息透明度指数）和企业气候行动指数。IPE从生态环境部、地方环保部门和上市公司环境披露中采集数据，生成交互式地图、省级双碳指数和供应链环境风险评级，被跨国企业、投资机构和政策制定者广泛使用。"
+  },
+  "website": "https://www.ipe.org.cn",
+  "data_url": "https://www.ipe.org.cn/AirMap_fxy/AirMap.html",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "environment",
+    "climate",
+    "pollution",
+    "corporate-governance",
+    "sustainability"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "公众环境研究中心",
+    "IPE",
+    "蔚蓝地图",
+    "Blue Map",
+    "pollution",
+    "污染",
+    "air quality",
+    "空气质量",
+    "water pollution",
+    "水污染",
+    "soil contamination",
+    "土壤污染",
+    "carbon emissions",
+    "碳排放",
+    "双碳",
+    "dual-carbon",
+    "supply chain",
+    "供应链",
+    "CITI指数",
+    "green supply chain",
+    "绿色供应链",
+    "environmental disclosure",
+    "环境信息披露",
+    "ESG",
+    "corporate sustainability",
+    "企业碳中和",
+    "biodiversity",
+    "生物多样性",
+    "provincial carbon index",
+    "省级双碳指数",
+    "climate action",
+    "气候行动"
+  ],
+  "data_content": {
+    "en": [
+      "Air Quality Database: Real-time and historical air pollution records (PM2.5, PM10, SO2, NOx, CO, O3) from thousands of monitoring stations across all Chinese cities",
+      "Water Pollution Records: Enterprise wastewater discharge violations, river basin water quality assessments, and drinking water source protection data",
+      "Soil Contamination: Industrial pollution sources, contaminated site records, and soil remediation progress",
+      "Carbon & Energy Maps: Provincial carbon emission indexes, energy transition tracking, photovoltaic installation mapping, and enterprise carbon disclosure",
+      "Supply Chain CITI Index: Environmental transparency and compliance ratings for thousands of Chinese suppliers used by global brands",
+      "Corporate Climate Action Index: Assessment of listed companies' climate commitments, emission reduction targets, and green investment",
+      "Biodiversity Data: Natural reserve mapping, ecological red-line areas, and species diversity monitoring",
+      "Radiation Monitoring: Nuclear facility radiation monitoring data from environmental protection agencies"
+    ],
+    "zh": [
+      "空气质量数据库：全国城市数千个监测站的PM2.5、PM10、SO2、NOx、CO、O3实时和历史数据",
+      "水污染记录：企业废水排放违规记录、流域水质评估和饮用水源保护数据",
+      "土壤污染：工业污染源、污染地块台账和土壤修复进展",
+      "碳排放与能源地图：省级双碳指数、能源转型追踪、光伏装机地图和企业碳披露",
+      "供应链CITI指数：全球品牌使用的数千家中国供应商的环境透明度和合规评级",
+      "企业气候行动指数：上市公司气候承诺、减排目标和绿色投资评估",
+      "生物多样性：自然保护区地图、生态红线范围和物种多样性监测",
+      "辐射监测：环保部门核设施周边辐射监测数据"
+    ]
+  }
+}


### PR DESCRIPTION
## 新增5个中国权威数据源（上午批次 2026-04-26）

本次新增以下5个中国权威数据源：

### 1. 🌤 china-nmic — 国家气象信息中心 (data.cma.cn)
- **类型**: 政府机构
- **领域**: 气象、气候、地球科学、农业
- **说明**: 中国气象局下属专业机构，运营中国气象数据网，提供2400+国家站和6万余个自动站的观测数据、卫星产品、雷达、气候再分析等

### 2. 🌿 china-ipe — 公众环境研究中心 (ipe.org.cn)
- **类型**: 研究机构/NGO
- **领域**: 环境、气候、污染、企业治理、可持续发展
- **说明**: 中国领先的环境NGO，运营蔚蓝地图污染数据库，覆盖大气/水体/土壤/辐射/碳排放，提供供应链CITI指数和省级双碳指数

### 3. 🏦 china-pbccrc — 中国人民银行征信中心 (pbccrc.org.cn)
- **类型**: 政府机构
- **领域**: 金融、信用、银行、经济
- **说明**: 全球最大信用数据库之一，维护11亿+自然人和6000万+企业信用记录，发布社会融资规模统计数据

### 4. 🎓 china-pku-opendata — 北京大学开放研究数据平台 (opendata.pku.edu.cn)
- **类型**: 研究机构
- **领域**: 社会科学、经济、健康、环境、科学
- **说明**: 中国第一个综合性机构开放研究数据平台，基于Harvard Dataverse，托管北大各学科研究数据集

### 5. 🔬 china-cstr — 科技资源标识服务平台 (cstr.cn)
- **类型**: 政府机构
- **领域**: 科学、地球科学、生物、材料、天文
- **说明**: 科技部国家科技基础条件平台中心运营的国家级科学数据持久标识体系，相当于科学数据的DOI系统

## 验证清单
- [x] ID去重：全部通过
- [x] 域名去重：全部通过（含open PR）
- [x] 黑名单检查：全部通过
- [x] website URL验证：全部返回200/301/302
- [x] data_url验证：全部返回200
- [x] 网站title核实：与声称机构一致
- [x] `make check` 通过：545个ID唯一，schema验证全通过
- [x] 9条坑检查：全部合规（数组、连字符域名等）