### PR TITLE
feat: add 5 China authoritative data sources (PM batch 2026-04-27)

### DIFF
--- a/firstdata/sources/china/economy/agriculture/china-natesc.json
+++ b/firstdata/sources/china/economy/agriculture/china-natesc.json
@@ -1,0 +1,73 @@
+{
+  "id": "china-natesc",
+  "name": {
+    "en": "National Agro-Tech Extension and Service Center",
+    "zh": "全国农业技术推广服务中心"
+  },
+  "description": {
+    "en": "The National Agro-Tech Extension and Service Center (NATESC) is a national public institution under China's Ministry of Agriculture and Rural Affairs (MARA), responsible for organizing and guiding agricultural technology extension, crop disease and pest monitoring, seed quality testing, and soil fertility assessment across China. Established in 1994, NATESC coordinates the national agricultural extension network linking central, provincial, and county-level stations, managing information systems on crop growth monitoring, pest and disease surveillance, fertilizer usage, and agricultural inputs. It publishes annual crop pest early-warning bulletins, soil fertility surveys, agricultural technology adoption statistics, and farm input data that support agricultural production planning and food security policy formulation.",
+    "zh": "全国农业技术推广服务中心（全国农技推广中心）是农业农村部下属全国性公益性机构，负责组织和指导全国农业技术推广、农作物病虫害监测、种子质量检测和土壤肥力评估工作。中心成立于1994年，协调贯通县、省、部三级农业技术推广网络，管理作物生长监测、病虫害监测、化肥施用和农业投入品等信息系统。中心发布年度作物病虫害早期预警公告、土壤肥力调查报告、农业技术应用统计和农资数据，支撑农业生产计划和粮食安全政策制定。"
+  },
+  "website": "http://www.natesc.org.cn",
+  "data_url": "http://www.natesc.org.cn",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "agriculture",
+    "technology",
+    "environment",
+    "social"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "全国农业技术推广服务中心",
+    "全国农技推广",
+    "NATESC",
+    "National Agro-Tech Extension and Service Center",
+    "农业技术推广",
+    "agricultural technology extension",
+    "病虫害监测",
+    "pest and disease monitoring",
+    "农作物病虫害",
+    "crop pests and diseases",
+    "土壤肥力",
+    "soil fertility",
+    "化肥",
+    "fertilizer",
+    "种子质量",
+    "seed quality",
+    "农业投入品",
+    "agricultural inputs",
+    "粮食安全",
+    "food security",
+    "农技推广网络",
+    "agro-tech extension network",
+    "作物生长监测",
+    "crop growth monitoring",
+    "农业部",
+    "MARA",
+    "农业农村部"
+  ],
+  "data_content": {
+    "en": [
+      "Crop pest and disease monitoring: national surveillance data on major crop pests (locusts, aphids, etc.) and diseases across China's farming regions",
+      "Early-warning bulletins: seasonal and annual early-warning reports on crop pest outbreaks and disease epidemics",
+      "Soil fertility surveys: periodic national soil nutrient status assessments and fertilizer recommendation data",
+      "Fertilizer usage statistics: annual data on fertilizer application rates, types, and trends across China's agricultural regions",
+      "Seed quality testing reports: inspection results for crop seed varieties on germination rates, purity, and moisture content",
+      "Agricultural technology adoption statistics: data on diffusion of new crop varieties, farming techniques, and mechanization",
+      "Crop growth monitoring bulletins: periodic crop condition assessments and yield forecast data during growing seasons"
+    ],
+    "zh": [
+      "农作物病虫害监测：中国农业区主要作物病虫害（蝗虫、蚜虫等）全国监测数据",
+      "早期预警公告：作物病虫害暴发和疫情的季节性和年度早期预警报告",
+      "土壤肥力调查：定期全国土壤养分状况评估和化肥施用建议数据",
+      "化肥施用统计：中国各农业区化肥施用量、种类和趋势年度数据",
+      "种子质量检测报告：作物种子品种发芽率、纯度和水分含量检测结果",
+      "农业技术应用统计：新品种、农业技术和机械化推广应用数据",
+      "作物生长监测公告：生长季节定期作物长势评估和产量预报数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/economy/agriculture/china-natesc.json
+++ b/firstdata/sources/china/economy/agriculture/china-natesc.json
@@ -8,8 +8,8 @@
     "en": "The National Agro-Tech Extension and Service Center (NATESC) is a national public institution under China's Ministry of Agriculture and Rural Affairs (MARA), responsible for organizing and guiding agricultural technology extension, crop disease and pest monitoring, seed quality testing, and soil fertility assessment across China. Established in 1994, NATESC coordinates the national agricultural extension network linking central, provincial, and county-level stations, managing information systems on crop growth monitoring, pest and disease surveillance, fertilizer usage, and agricultural inputs. It publishes annual crop pest early-warning bulletins, soil fertility surveys, agricultural technology adoption statistics, and farm input data that support agricultural production planning and food security policy formulation.",
     "zh": "全国农业技术推广服务中心（全国农技推广中心）是农业农村部下属全国性公益性机构，负责组织和指导全国农业技术推广、农作物病虫害监测、种子质量检测和土壤肥力评估工作。中心成立于1994年，协调贯通县、省、部三级农业技术推广网络，管理作物生长监测、病虫害监测、化肥施用和农业投入品等信息系统。中心发布年度作物病虫害早期预警公告、土壤肥力调查报告、农业技术应用统计和农资数据，支撑农业生产计划和粮食安全政策制定。"
   },
-  "website": "http://www.natesc.org.cn",
-  "data_url": "http://www.natesc.org.cn",
+  "website": "https://www.natesc.org.cn",
+  "data_url": "https://www.natesc.org.cn",
   "api_url": null,
   "authority_level": "government",
   "country": "CN",

--- a/firstdata/sources/china/governance/china-cppcc.json
+++ b/firstdata/sources/china/governance/china-cppcc.json
@@ -1,0 +1,66 @@
+{
+  "id": "china-cppcc",
+  "name": {
+    "en": "Chinese People's Political Consultative Conference",
+    "zh": "中国人民政治协商会议"
+  },
+  "description": {
+    "en": "The Chinese People's Political Consultative Conference (CPPCC) is a key institution of China's political system functioning as the country's main political advisory body. Established in 1949, the CPPCC brings together representatives from political parties, people's organizations, ethnic minorities, and various social sectors to provide political consultation and democratic oversight. The CPPCC National Committee meets annually alongside the National People's Congress in the 'Two Sessions'. It publishes proposals, motion documents, committee reports, and consultative deliberation outcomes across economic, social, cultural, and environmental policy areas. The CPPCC website provides access to official documents, proposals submitted by members, research reports, and proceedings from plenary sessions and standing committee meetings.",
+    "zh": "中国人民政治协商会议（全国政协）是中国政治体系的重要机构，是国家最高政治协商机构。1949年成立，全国政协汇聚各民主党派、人民团体、少数民族和各社会界别代表，履行政治协商、民主监督、参政议政职能。全国政协常委会每年与全国人大共同召开「两会」。全国政协网站提供官方文件、委员提案、研究报告、全体会议及常委会会议纪要，涵盖经济、社会、文化和环境政策等各领域。"
+  },
+  "website": "http://www.cppcc.gov.cn",
+  "data_url": "http://www.cppcc.gov.cn",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "governance",
+    "political-science",
+    "social",
+    "economics"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "全国政协",
+    "CPPCC",
+    "Chinese People's Political Consultative Conference",
+    "政治协商",
+    "political consultation",
+    "提案",
+    "proposals",
+    "民主监督",
+    "democratic oversight",
+    "参政议政",
+    "两会",
+    "Two Sessions",
+    "政协委员",
+    "committee members",
+    "政协常委会",
+    "standing committee",
+    "政协全体会议",
+    "plenary session",
+    "政协报告",
+    "CPPCC reports"
+  ],
+  "data_content": {
+    "en": [
+      "CPPCC member proposals: formal policy proposals submitted by committee members across economic, social, cultural, and environmental areas",
+      "Committee reports: annual work reports of the CPPCC National Committee and standing committee",
+      "Plenary session records: proceedings and resolutions from the annual National Committee sessions",
+      "Standing committee meeting documents: records of bimonthly standing committee meetings and deliberations",
+      "Special committee research: investigation and research reports from CPPCC specialized committees on key policy topics",
+      "Democratic oversight documents: feedback and recommendations on implementation of major national policies",
+      "Consultative deliberation outcomes: results of consultative conferences on specific economic and social policy issues"
+    ],
+    "zh": [
+      "全国政协委员提案：委员就经济、社会、文化、环境等领域提交的正式政策建议",
+      "委员会报告：全国政协委员会及常委会年度工作报告",
+      "全体会议记录：全国委员会年度会议的议程及决议",
+      "常委会会议文件：两月一次常委会会议记录及审议结论",
+      "专门委员会研究：政协各专门委员会就重大政策课题开展的调研报告",
+      "民主监督文件：对重大国家政策贯彻落实情况的意见与建议",
+      "协商座谈成果：就具体经济社会政策议题召开协商座谈会的成果文件"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-casm.json
+++ b/firstdata/sources/china/research/china-casm.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-casm",
+  "name": {
+    "en": "Chinese Academy of Surveying and Mapping",
+    "zh": "中国测绘科学研究院"
+  },
+  "description": {
+    "en": "The Chinese Academy of Surveying and Mapping (CASM) is the national research institution for surveying, mapping, and geoinformation under China's Ministry of Natural Resources. Founded in 1959, CASM conducts cutting-edge research on geodesy, cartography, remote sensing, geographic information systems (GIS), and spatial data infrastructure. It is responsible for developing national surveying and mapping standards, technical norms, and theoretical frameworks for China's geospatial information industry. CASM maintains and produces key national geodetic datasets, digital elevation models, topographic maps, and geospatial reference frameworks. It also conducts research on satellite navigation and positioning (BeiDou/GNSS), photogrammetry, and marine surveying technologies, contributing to national spatial data infrastructure development and international mapping cooperation.",
+    "zh": "中国测绘科学研究院（CASM）是自然资源部下属的测绘、地图制图和地理信息国家级研究机构，成立于1959年。中心在大地测量、地图制图、遥感、地理信息系统（GIS）和空间数据基础设施领域开展前沿研究，负责制定中国测绘行业国家标准、技术规范和理论框架。中心维护和生产国家大地测量数据集、数字高程模型、地形图和地理空间参考框架，并在卫星导航定位（北斗/GNSS）、摄影测量和海洋测绘技术领域开展研究，推动国家空间数据基础设施建设和国际测绘合作。"
+  },
+  "website": "https://www.casm.ac.cn",
+  "data_url": "https://www.casm.ac.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "geography",
+    "remote-sensing",
+    "infrastructure",
+    "technology"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国测绘科学研究院",
+    "CASM",
+    "Chinese Academy of Surveying and Mapping",
+    "测绘",
+    "surveying and mapping",
+    "大地测量",
+    "geodesy",
+    "地图制图",
+    "cartography",
+    "地理信息",
+    "geographic information",
+    "GIS",
+    "遥感",
+    "remote sensing",
+    "空间数据",
+    "spatial data",
+    "数字高程模型",
+    "DEM",
+    "digital elevation model",
+    "地形图",
+    "topographic map",
+    "北斗",
+    "BeiDou",
+    "GNSS",
+    "摄影测量",
+    "photogrammetry",
+    "测绘标准",
+    "mapping standards",
+    "地理空间",
+    "geospatial"
+  ],
+  "data_content": {
+    "en": [
+      "Geodetic datasets: national geodetic control networks, reference frames, and precise coordinate data for surveying benchmarks across China",
+      "Digital elevation models: national DEM products at various resolutions derived from topographic surveys and remote sensing",
+      "Topographic maps: digital and paper topographic map series covering mainland China at multiple scales",
+      "Geospatial standards: national standards and technical specifications for surveying, mapping, and geographic information systems in China",
+      "Remote sensing data products: processed satellite and airborne remote sensing imagery for mapping and change detection applications",
+      "BeiDou/GNSS positioning: research datasets and technical documentation related to China's BeiDou Navigation Satellite System applications",
+      "Marine surveying data: bathymetric charts and coastal zone survey datasets from China's territorial waters"
+    ],
+    "zh": [
+      "大地测量数据集：全国大地控制网、参考框架及遍布中国的测量基准精密坐标数据",
+      "数字高程模型：由地形测量和遥感数据生成的多分辨率国家DEM产品",
+      "地形图：覆盖中国大陆多比例尺的数字及纸质地形图系列",
+      "地理空间标准：中国测绘和地理信息系统领域的国家标准和技术规范",
+      "遥感数据产品：用于测绘和变化检测的星载及机载遥感影像处理产品",
+      "北斗/GNSS定位：与中国北斗卫星导航系统应用相关的研究数据集及技术文档",
+      "海洋测绘数据：中国领海区域水深图和海岸带测量数据集"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/environment/china-ncsc.json
+++ b/firstdata/sources/china/resources/environment/china-ncsc.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-ncsc",
+  "name": {
+    "en": "National Center for Climate Change Strategy and International Cooperation",
+    "zh": "国家应对气候变化战略研究和国际合作中心"
+  },
+  "description": {
+    "en": "The National Center for Climate Change Strategy and International Cooperation (NCSC) is a specialized think tank under China's Ministry of Ecology and Environment (MEE), established in 2012. NCSC serves as China's primary policy research institution on climate change, responsible for strategic research on national greenhouse gas emissions reduction, carbon market policy, climate finance, and international climate negotiations. It supports China's participation in UNFCCC negotiations and conducts research on the Paris Agreement implementation. NCSC produces annual China's Policies and Actions for Addressing Climate Change reports, emissions inventory studies, low-carbon transition pathway analyses, and carbon pricing mechanism research that directly inform China's climate governance and policy formulation.",
+    "zh": "国家应对气候变化战略研究和国际合作中心（NCSC）是生态环境部下属专业智库，成立于2012年，是中国应对气候变化领域主要政策研究机构。NCSC负责国家温室气体减排、碳市场政策、气候融资和国际气候谈判战略研究，支持中国参与《联合国气候变化框架公约》谈判，并就《巴黎协定》实施开展研究。中心每年发布《中国应对气候变化的政策与行动》年度报告，开展温室气体排放清单研究、低碳转型路径分析和碳定价机制研究，直接支撑中国气候治理和政策制定。"
+  },
+  "website": "http://www.ncsc.org.cn",
+  "data_url": "http://www.ncsc.org.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "climate",
+    "environment",
+    "energy",
+    "economics"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "国家应对气候变化战略研究和国际合作中心",
+    "NCSC",
+    "National Center for Climate Change Strategy",
+    "气候变化",
+    "climate change",
+    "温室气体",
+    "greenhouse gas",
+    "碳市场",
+    "carbon market",
+    "碳排放",
+    "carbon emissions",
+    "低碳",
+    "low carbon",
+    "气候政策",
+    "climate policy",
+    "巴黎协定",
+    "Paris Agreement",
+    "UNFCCC",
+    "碳中和",
+    "carbon neutrality",
+    "双碳",
+    "dual carbon",
+    "气候融资",
+    "climate finance",
+    "国际气候谈判",
+    "international climate negotiations",
+    "碳定价",
+    "carbon pricing",
+    "排放清单",
+    "emissions inventory"
+  ],
+  "data_content": {
+    "en": [
+      "China's climate action annual reports: comprehensive annual assessment of China's policies and actions for addressing climate change",
+      "Greenhouse gas emissions inventory: national and sectoral GHG emissions data and inventory methodologies",
+      "Carbon market research: analysis of China's national emissions trading scheme (ETS), allowance allocation, and market performance",
+      "Low-carbon transition pathways: scenario analyses and roadmaps for decarbonizing China's energy, industry, and transport sectors",
+      "International climate negotiation positions: policy briefs and analysis on China's stance in UNFCCC and Paris Agreement negotiations",
+      "Climate finance data: research on green finance flows, climate investment, and mobilization of private capital for low-carbon development",
+      "Carbon pricing mechanism studies: comparative analysis of carbon taxes, ETS designs, and policy effectiveness across countries"
+    ],
+    "zh": [
+      "中国气候行动年度报告：中国应对气候变化政策与行动的综合年度评估报告",
+      "温室气体排放清单：国家和分行业温室气体排放数据及清单方法学",
+      "碳市场研究：中国全国碳排放权交易市场（ETS）、配额分配和市场运行分析",
+      "低碳转型路径：中国能源、工业和交通部门脱碳情景分析和路线图",
+      "国际气候谈判立场：中国参与UNFCCC和《巴黎协定》谈判的政策简报和分析",
+      "气候融资数据：绿色金融流量、气候投资及低碳发展私人资本动员研究",
+      "碳定价机制研究：各国碳税、碳交易机制设计和政策效果比较分析"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/ocean/china-nsoas.json
+++ b/firstdata/sources/china/resources/ocean/china-nsoas.json
@@ -1,0 +1,75 @@
+{
+  "id": "china-nsoas",
+  "name": {
+    "en": "National Satellite Ocean Application Service",
+    "zh": "国家卫星海洋应用中心"
+  },
+  "description": {
+    "en": "The National Satellite Ocean Application Service (NSOAS) is the specialized agency under China's Ministry of Natural Resources responsible for the operational application of ocean satellites and marine remote sensing data. NSOAS manages China's HY (Haiyang/Ocean) satellite series, including HY-1 and HY-2 satellites for ocean color observation, sea surface temperature, wind fields, and sea level measurement. It serves as the national center for ocean satellite data reception, processing, archiving, and distribution, providing remote sensing products to governmental agencies, research institutions, and international partners. NSOAS publishes ocean environmental monitoring data, satellite-derived marine datasets, and conducts application research in fishery monitoring, sea ice observation, and coastal zone management.",
+    "zh": "国家卫星海洋应用中心是自然资源部下属专业机构，负责海洋卫星和海洋遥感数据的业务化应用。中心负责管理中国海洋（HY）系列卫星，包括用于海洋水色观测、海面温度、风场和海面高度测量的HY-1和HY-2卫星。作为全国海洋卫星数据接收、处理、存档和分发国家中心，向政府部门、科研机构和国际合作伙伴提供遥感产品。中心发布海洋环境监测数据、卫星海洋数据集，并在渔业监测、海冰观测和海岸带管理等领域开展应用研究。"
+  },
+  "website": "http://www.nsoas.org.cn",
+  "data_url": "http://www.nsoas.org.cn",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "ocean",
+    "environment",
+    "climate",
+    "remote-sensing"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "国家卫星海洋应用中心",
+    "NSOAS",
+    "National Satellite Ocean Application Service",
+    "海洋卫星",
+    "ocean satellite",
+    "HY卫星",
+    "HY satellite",
+    "Haiyang satellite",
+    "海洋遥感",
+    "ocean remote sensing",
+    "海面温度",
+    "sea surface temperature",
+    "SST",
+    "海洋水色",
+    "ocean color",
+    "风场",
+    "wind field",
+    "海平面",
+    "sea level",
+    "海冰",
+    "sea ice",
+    "渔业监测",
+    "fishery monitoring",
+    "海岸带",
+    "coastal zone",
+    "卫星数据",
+    "satellite data",
+    "海洋环境监测",
+    "marine environmental monitoring"
+  ],
+  "data_content": {
+    "en": [
+      "Ocean color data: chlorophyll-a concentration, suspended sediment, and ocean color products derived from HY-1 satellite imagery",
+      "Sea surface temperature: satellite-measured SST products covering China's sea areas and adjacent oceans",
+      "Sea surface wind fields: ocean wind speed and direction measurements from HY-2 microwave scatterometers",
+      "Sea surface height and waves: altimetry-derived sea level anomaly and significant wave height datasets",
+      "Sea ice monitoring: seasonal sea ice extent, concentration, and thickness data for polar and China's sea areas",
+      "Fishery resources monitoring: satellite-derived data supporting marine fishery stock assessment and fishing ground prediction",
+      "Coastal zone remote sensing: high-resolution satellite imagery and derived products for coastal land-sea interface monitoring"
+    ],
+    "zh": [
+      "海洋水色数据：基于HY-1卫星图像的叶绿素a浓度、悬浮泥沙和海洋水色产品",
+      "海面温度：覆盖中国海域及邻近海洋的卫星海面温度产品",
+      "海面风场：HY-2微波散射计测量的海面风速和风向",
+      "海面高度与波浪：高度计反演的海面高度异常和有效波高数据集",
+      "海冰监测：极地和中国海域的季节性海冰范围、密集度和厚度数据",
+      "渔业资源监测：支持海洋渔业资源评估和渔场预报的卫星反演数据",
+      "海岸带遥感：用于海岸带陆海交互监测的高分辨率卫星影像及衍生产品"
+    ]
+  }
+}


### PR DESCRIPTION
## 新增5个中国权威数据源（下午批次）

### 数据源列表

| ID | 机构名称 | 领域 | 权威级别 |
|---|---|---|---|
| `china-cppcc` | 中国人民政治协商会议 | governance, political-science, social | government |
| `china-nsoas` | 国家卫星海洋应用中心 | ocean, environment, climate, remote-sensing | government |
| `china-ncsc` | 国家应对气候变化战略研究和国际合作中心 | climate, environment, energy, economics | research |
| `china-casm` | 中国测绘科学研究院 | geography, remote-sensing, infrastructure, technology | research |
| `china-natesc` | 全国农业技术推广服务中心 | agriculture, technology, environment | government |

### 验证情况

- ✅ ID 去重（对比现有583条记录）
- ✅ 域名去重（对比现有538个域名）
- ✅ 黑名单检查通过
- ✅ 网站可访问性验证（200/301 响应）
- ✅ 网站标题与机构名称一致
- ✅ `make check` 全部通过（545条记录，无重复ID，域名一致性通过）
- ⚠️ 所有深链路径返回404，data_url 均使用根路径（遵循规则）