### PR TITLE
feat: add 5 China authority data sources (AM batch 2026-04-28)

### DIFF
--- a/firstdata/sources/china/health/china-cpma.json
+++ b/firstdata/sources/china/health/china-cpma.json
@@ -1,0 +1,79 @@
+{
+  "id": "china-cpma",
+  "name": {
+    "en": "Chinese Preventive Medicine Association",
+    "zh": "中华预防医学会"
+  },
+  "description": {
+    "en": "The Chinese Preventive Medicine Association (CPMA) is China's largest national-level academic association in the field of public health and preventive medicine, established in 1987 under the supervision of the National Health Commission. CPMA unites over 400,000 public health professionals and 89 professional branches covering epidemiology, occupational health, nutrition, environmental health, school health, and health statistics. The association publishes key academic journals, organizes national public health surveillance research, and issues clinical guidelines and technical standards for disease prevention and control. CPMA plays a central role in translating evidence-based public health research into national prevention policies, vaccination programs, and non-communicable disease intervention strategies. It coordinates with WHO and international public health organizations on global health initiatives.",
+    "zh": "中华预防医学会是中国最大的公共卫生和预防医学领域全国性学术团体，1987年在国家卫生健康委员会主管下成立，拥有40余万名公共卫生专业人员和89个专业分会，涵盖流行病学、职业卫生、营养、环境卫生、学校卫生和卫生统计等领域。学会出版重要学术期刊，组织全国公共卫生监测研究，发布疾病预防控制临床指南和技术规范。中华预防医学会在将循证公共卫生研究转化为国家预防政策、疫苗接种规划和慢性病干预策略方面发挥核心作用，并与世界卫生组织及国际公共卫生组织协调开展全球卫生行动。"
+  },
+  "website": "https://www.cpma.org.cn",
+  "data_url": "https://www.cpma.org.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "health",
+    "science",
+    "social"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中华预防医学会",
+    "CPMA",
+    "Chinese Preventive Medicine Association",
+    "公共卫生",
+    "public health",
+    "预防医学",
+    "preventive medicine",
+    "流行病学",
+    "epidemiology",
+    "职业卫生",
+    "occupational health",
+    "营养学",
+    "nutrition",
+    "环境卫生",
+    "environmental health",
+    "学校卫生",
+    "school health",
+    "卫生统计",
+    "health statistics",
+    "疾病预防",
+    "disease prevention",
+    "疫苗接种",
+    "vaccination",
+    "慢性病",
+    "non-communicable disease",
+    "NCD",
+    "卫生政策",
+    "health policy",
+    "全球卫生",
+    "global health",
+    "WHO",
+    "世界卫生组织"
+  ],
+  "data_content": {
+    "en": [
+      "Epidemiological surveillance data: national disease burden estimates, outbreak investigation reports, and long-term epidemiological cohort study data for major communicable and non-communicable diseases",
+      "Public health guidelines and standards: evidence-based clinical practice guidelines for disease prevention, technical standards for health examination, and occupational health assessment criteria",
+      "Vaccination program data: immunization schedule recommendations, vaccine safety monitoring reports, and vaccination coverage surveys across Chinese provinces",
+      "Nutrition and dietary surveys: national nutrition status data, dietary pattern analyses, micronutrient deficiency prevalence, and dietary guideline development data for Chinese populations",
+      "Occupational health data: work-related disease statistics, occupational exposure limit standards, workplace health hazard assessments, and industrial hygiene monitoring data",
+      "Environmental health research: environmental exposure assessment studies, environmental epidemiology data for air, water, and soil pollution impacts on human health",
+      "School and child health: student physical fitness surveillance, school environment health assessments, adolescent health monitoring, and eye health data",
+      "Academic publications: peer-reviewed research from Chinese Journal of Preventive Medicine and 10+ CPMA-affiliated journals covering all major public health domains"
+    ],
+    "zh": [
+      "流行病学监测数据：重大传染病和慢性病的全国疾病负担估算、暴发事件调查报告和长期流行病学队列研究数据",
+      "公共卫生指南和标准：疾病预防循证临床实践指南、健康检查技术规范和职业健康评估标准",
+      "疫苗接种规划数据：免疫接种时间表建议、疫苗安全监测报告和全国各省接种率调查",
+      "营养和膳食调查：全国营养状况数据、膳食结构分析、微量营养素缺乏流行率和中国居民膳食指南制定数据",
+      "职业卫生数据：职业病统计、职业接触限值标准、工作场所危害评估和工业卫生监测数据",
+      "环境卫生研究：环境暴露评估研究、空气、水和土壤污染对人体健康影响的环境流行病学数据",
+      "学校和儿童健康：学生体质监测、学校环境卫生评估、青少年健康监测和视力健康数据",
+      "学术出版物：《中华预防医学杂志》及10余种中华预防医学会下属期刊的所有公共卫生领域同行评审研究"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-cisri.json
+++ b/firstdata/sources/china/research/china-cisri.json
@@ -1,0 +1,79 @@
+{
+  "id": "china-cisri",
+  "name": {
+    "en": "China Iron & Steel Research Institute Group",
+    "zh": "中国钢研科技集团有限公司"
+  },
+  "description": {
+    "en": "The China Iron & Steel Research Institute Group (CISRI), formerly the Iron and Steel Research Institute, is China's premier state-owned research institution specializing in metallurgy, advanced steel materials, and new materials technology. Founded in 1952 and affiliated with the State-owned Assets Supervision and Administration Commission (SASAC), CISRI is the national authority for steel and metallic materials research, testing, and standardization. It operates the National Steel Quality Supervision and Inspection Center and maintains reference material databases for Chinese metallurgical standards. CISRI publishes authoritative technical data on steel grades, material properties, failure analysis, and corrosion behavior, serving as the technical backbone for China's iron and steel industry. The institute develops national and industry standards for steel products and contributes to international standards bodies including ISO TC17 (steel). CISRI's research spans special steels for aerospace, energy, transportation, and defense applications, as well as environmental metallurgy and recycling.",
+    "zh": "中国钢研科技集团有限公司（中国钢研）原为冶金研究院，是中国顶级冶金、先进钢铁材料和新材料技术领域的国有研究机构，1952年创建，隶属国务院国有资产监督管理委员会（国资委）。中国钢研是钢铁和金属材料研究、检测和标准化领域的国家权威机构，运营国家钢铁质量监督检验中心，维护中国冶金标准标准物质数据库。公司发布钢铁牌号、材料性能、失效分析和腐蚀行为权威技术数据，是中国钢铁工业技术支撑核心。研究所制定钢铁产品国家和行业标准，并参与ISO TC17（钢铁）等国际标准化机构。中国钢研的研究涵盖航空、能源、交通和国防应用的特种钢，以及环境冶金和再生利用。"
+  },
+  "website": "https://www.cisri.com.cn",
+  "data_url": "https://www.cisri.com.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "industry",
+    "science",
+    "technology"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国钢研科技集团",
+    "CISRI",
+    "China Iron Steel Research Institute",
+    "冶金",
+    "metallurgy",
+    "钢铁",
+    "steel",
+    "金属材料",
+    "metallic materials",
+    "特种钢",
+    "special steel",
+    "钢铁标准",
+    "steel standards",
+    "材料性能",
+    "material properties",
+    "失效分析",
+    "failure analysis",
+    "腐蚀",
+    "corrosion",
+    "标准物质",
+    "reference materials",
+    "国家钢铁质量监督检验",
+    "steel quality inspection",
+    "新材料",
+    "new materials",
+    "航空材料",
+    "aerospace materials",
+    "ISO TC17",
+    "国资委",
+    "SASAC",
+    "环境冶金",
+    "environmental metallurgy"
+  ],
+  "data_content": {
+    "en": [
+      "Steel grade standards database: comprehensive records of Chinese national steel grade classifications (GB standards), chemical composition specifications, and mechanical property requirements for thousands of steel products",
+      "Material property databases: tensile strength, yield strength, hardness, impact toughness, fatigue life, and creep data for carbon steels, alloy steels, stainless steels, and tool steels under various conditions",
+      "Failure analysis case data: metallurgical failure investigation reports for industrial accidents, equipment failures, and product defects, supporting industry safety and quality improvement",
+      "Corrosion behavior data: electrochemical corrosion, stress corrosion cracking, and environmentally-assisted cracking data for steels in atmospheric, marine, and industrial environments",
+      "Reference materials: certified standard reference materials for spectrochemical analysis of iron and steel, providing traceability for quality control in steel production",
+      "Special and advanced materials research: data on high-strength steels, heat-resistant steels, electrical steels, bearing steels, and tool steels for aerospace, energy, and defense applications",
+      "Steel production process data: research outputs on iron and steelmaking technologies, continuous casting, rolling, heat treatment, and surface treatment optimization",
+      "Environmental metallurgy and recycling: scrap steel characterization data, secondary metallurgy research, and life cycle assessment for steel production processes"
+    ],
+    "zh": [
+      "钢铁牌号标准数据库：数千种钢铁产品的中国国家钢铁牌号分类（GB标准）、化学成分规范和力学性能要求综合记录",
+      "材料性能数据库：碳钢、合金钢、不锈钢和工具钢在各种条件下的抗拉强度、屈服强度、硬度、冲击韧性、疲劳寿命和蠕变数据",
+      "失效分析案例数据：工业事故、设备故障和产品缺陷的冶金失效调查报告，支持行业安全和质量改进",
+      "腐蚀行为数据：钢铁在大气、海洋和工业环境中的电化学腐蚀、应力腐蚀开裂和环境辅助开裂数据",
+      "标准物质：钢铁光谱化学分析认证标准物质，为钢铁生产质量控制提供溯源性依据",
+      "特种和先进材料研究：航空、能源和国防应用的高强度钢、耐热钢、电工钢、轴承钢和工具钢数据",
+      "钢铁生产工艺数据：炼铁炼钢技术、连铸、轧制、热处理和表面处理优化的研究成果",
+      "环境冶金和再生利用：废钢特征化数据、二次冶金研究和钢铁生产工艺的生命周期评估"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-ibcas.json
+++ b/firstdata/sources/china/research/china-ibcas.json
@@ -1,0 +1,82 @@
+{
+  "id": "china-ibcas",
+  "name": {
+    "en": "Institute of Botany, Chinese Academy of Sciences",
+    "zh": "中国科学院植物研究所"
+  },
+  "description": {
+    "en": "The Institute of Botany (IBCAS) under the Chinese Academy of Sciences is China's flagship research institution for plant science, established in 1928. IBCAS maintains the China National Herbarium (PE), one of the world's largest plant specimen repositories, housing over 2.8 million voucher specimens representing China's extraordinary plant diversity. The institute operates the Beijing Botanical Garden and the China Specimen Information System, and contributes to international flora databases. IBCAS leads research in plant systematics and evolution, plant ecology, plant physiology, and molecular biology of plants. It coordinates the Flora of China project—a landmark collaboration with Missouri Botanical Garden—and publishes the authoritative Chinese Flora records. IBCAS manages critical plant diversity databases including the Chinese Virtual Herbarium and China Species Information Service, providing foundational data for biodiversity conservation, ecological restoration, and phytochemistry research.",
+    "zh": "中国科学院植物研究所是中国植物科学领域的旗舰研究机构，1928年建立。植物所保管中国国家植物标本馆（PE），是世界上最大的植物标本库之一，收藏280余万份植物标本，代表中国卓越的植物多样性。研究所运营北京植物园和中国标本信息系统，并为国际植物志数据库做出重要贡献。植物所在植物系统学与进化、植物生态学、植物生理学和植物分子生物学领域引领全国研究，与密苏里植物园合作主持《中国植物志》英文版项目，发布权威中国植物志记录。植物所管理中国虚拟植物标本馆和中国物种信息服务等重要植物多样性数据库，为生物多样性保护、生态修复和植物化学研究提供基础数据。"
+  },
+  "website": "https://www.ibcas.ac.cn",
+  "data_url": "https://www.ibcas.ac.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "biology",
+    "environment",
+    "science"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国科学院植物研究所",
+    "IBCAS",
+    "Institute of Botany",
+    "植物学",
+    "botany",
+    "植物多样性",
+    "plant diversity",
+    "生物多样性",
+    "biodiversity",
+    "植物标本",
+    "plant herbarium",
+    "中国国家植物标本馆",
+    "China National Herbarium",
+    "PE",
+    "Flora of China",
+    "中国植物志",
+    "植物系统学",
+    "plant systematics",
+    "植物进化",
+    "plant evolution",
+    "植物生态学",
+    "plant ecology",
+    "中国科学院",
+    "Chinese Academy of Sciences",
+    "CAS",
+    "北京植物园",
+    "Beijing Botanical Garden",
+    "种质资源",
+    "germplasm resources",
+    "植物化学",
+    "phytochemistry",
+    "生态修复",
+    "ecological restoration",
+    "中国虚拟植物标本馆",
+    "Chinese Virtual Herbarium"
+  ],
+  "data_content": {
+    "en": [
+      "China National Herbarium (PE) specimen database: 2.8+ million digitized plant voucher specimens with geographic coordinates, collection dates, taxonomic identifications, and high-resolution images",
+      "Flora of China records: comprehensive taxonomic treatments of approximately 31,000 Chinese vascular plant species, including descriptions, distribution maps, and synonymy",
+      "Chinese Virtual Herbarium: aggregated specimen data from major Chinese herbaria, enabling species distribution modeling and gap analysis for biodiversity conservation",
+      "China Species Information Service: authoritative species name lists, threat status assessments, and distribution data for Chinese plant species aligned with IUCN Red List criteria",
+      "Plant ecology datasets: vegetation survey data, plant community composition studies, phenological records, and ecosystem productivity measurements across Chinese biomes",
+      "Molecular phylogenetics data: DNA sequence databases and phylogenetic trees for Chinese plant families, supporting evolutionary biology research and species delimitation",
+      "Germplasm and conservation data: records of endangered plant species, in-situ and ex-situ conservation status, and genetic diversity assessments for priority conservation species",
+      "Phytochemistry research data: secondary metabolite databases, bioactive compound screening results, and ethnobotanical records of medicinal plants in China"
+    ],
+    "zh": [
+      "中国国家植物标本馆（PE）标本数据库：280余万份数字化植物凭证标本，含地理坐标、采集日期、分类鉴定和高分辨率图像",
+      "中国植物志记录：约31,000种中国维管植物的综合分类处理，包括描述、分布图和异名",
+      "中国虚拟植物标本馆：整合中国主要植物标本馆标本数据，支持物种分布模型和生物多样性保护空缺分析",
+      "中国物种信息服务：中国植物物种权威名录、受威胁状态评估和分布数据，与IUCN红色名录标准对接",
+      "植物生态学数据集：覆盖中国各生物群系的植被调查、植物群落组成研究、物候记录和生态系统生产力测量",
+      "分子系统学数据：中国植物科的DNA序列数据库和系统发育树，支持进化生物学研究和物种界定",
+      "种质和保护数据：濒危植物物种记录、就地与迁地保护状态和优先保护物种遗传多样性评估",
+      "植物化学研究数据：次生代谢产物数据库、生物活性化合物筛选结果和中国药用植物民族植物学记录"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-imcas.json
+++ b/firstdata/sources/china/research/china-imcas.json
@@ -1,0 +1,78 @@
+{
+  "id": "china-imcas",
+  "name": {
+    "en": "Institute of Microbiology, Chinese Academy of Sciences",
+    "zh": "中国科学院微生物研究所"
+  },
+  "description": {
+    "en": "The Institute of Microbiology (IMCAS) under the Chinese Academy of Sciences is China's premier research institution for microbiology, mycology, and microbial resources. Founded in 1958, IMCAS maintains the China General Microbiological Culture Collection Center (CGMCC), one of Asia's largest biological resource centers, housing hundreds of thousands of microbial strains, fungi, and viruses. The institute leads research in pathogenic microbiology, industrial microbiology, environmental microbiology, and bioinformatics. IMCAS publishes authoritative datasets on microbial diversity, antimicrobial resistance, and fungal taxonomy, contributing to global biological resource databases. Its research supports national biosafety, food fermentation industry, agricultural biocontrol, and pharmaceutical bioproduction. The institute is a key node in international microbial culture collection networks including WFCC and ECCO.",
+    "zh": "中国科学院微生物研究所是中国微生物学、真菌学和微生物资源领域的最高研究机构，1958年建立。微生物所维护中国普通微生物菌种保藏管理中心（CGMCC），是亚洲最大的生物资源库之一，保藏数十万株微生物菌株、真菌和病毒。研究所在病原微生物学、工业微生物学、环境微生物学和生物信息学领域引领全国研究，发布微生物多样性、抗微生物耐药性和真菌分类学权威数据集，为全球生物资源数据库贡献重要内容。其研究支撑国家生物安全、食品发酵产业、农业生物防治和医药生物生产。微生物所是世界菌种联合会（WFCC）和ECCO等国际微生物菌种保藏网络的重要节点。"
+  },
+  "website": "https://www.im.cas.cn",
+  "data_url": "https://www.im.cas.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "biology",
+    "health",
+    "science"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国科学院微生物研究所",
+    "IMCAS",
+    "Institute of Microbiology",
+    "微生物学",
+    "microbiology",
+    "真菌学",
+    "mycology",
+    "菌种保藏",
+    "microbial culture collection",
+    "CGMCC",
+    "中国普通微生物菌种保藏管理中心",
+    "微生物多样性",
+    "microbial diversity",
+    "抗微生物耐药性",
+    "antimicrobial resistance",
+    "AMR",
+    "生物安全",
+    "biosafety",
+    "工业微生物",
+    "industrial microbiology",
+    "病原微生物",
+    "pathogenic microbiology",
+    "真菌分类",
+    "fungal taxonomy",
+    "环境微生物",
+    "environmental microbiology",
+    "中国科学院",
+    "Chinese Academy of Sciences",
+    "CAS",
+    "微生物资源",
+    "microbial resources"
+  ],
+  "data_content": {
+    "en": [
+      "Microbial strain collections: CGMCC holds hundreds of thousands of authenticated bacterial, fungal, and viral strains available for research and industrial applications",
+      "Microbial diversity databases: catalogues of microbial species diversity across Chinese ecosystems, soil, marine, and extreme environments",
+      "Fungal taxonomy data: comprehensive records of fungal species classification, nomenclature, and morphological descriptions maintained by the Mycological Society of China",
+      "Antimicrobial resistance (AMR) monitoring: research datasets on drug-resistant pathogens, resistance gene databases, and surveillance reports",
+      "Genome sequence data: whole-genome sequences of bacteria, fungi, and viruses deposited in national and international databases",
+      "Industrial microbiology data: fermentation process parameters, enzyme databases, and biotransformation research for food, pharmaceutical, and agricultural applications",
+      "Environmental microbiology surveys: microbial community composition in soil, wastewater, and atmospheric environments across China",
+      "Biosafety research: risk assessment data for pathogenic microorganisms and containment standards for laboratory biosafety"
+    ],
+    "zh": [
+      "微生物菌种保藏：CGMCC保藏数十万株经鉴定的细菌、真菌和病毒菌株，供研究和工业应用",
+      "微生物多样性数据库：覆盖中国生态系统、土壤、海洋和极端环境的微生物物种多样性目录",
+      "真菌分类数据：中国菌物学会维护的真菌物种分类、命名和形态描述综合记录",
+      "抗微生物耐药性（AMR）监测：耐药病原体研究数据集、耐药基因数据库和监测报告",
+      "基因组序列数据：存入国内外数据库的细菌、真菌和病毒全基因组序列",
+      "工业微生物数据：食品、制药和农业应用的发酵工艺参数、酶数据库和生物转化研究",
+      "环境微生物调查：中国土壤、废水和大气环境中微生物群落组成",
+      "生物安全研究：病原微生物风险评估数据和实验室生物安全的防控标准"
+    ]
+  }
+}

--- a/firstdata/sources/china/resources/environment/china-craes.json
+++ b/firstdata/sources/china/resources/environment/china-craes.json
@@ -1,0 +1,78 @@
+{
+  "id": "china-craes",
+  "name": {
+    "en": "Chinese Research Academy of Environmental Sciences",
+    "zh": "中国环境科学研究院"
+  },
+  "description": {
+    "en": "The Chinese Research Academy of Environmental Sciences (CRAES), affiliated with the Ministry of Ecology and Environment, is China's highest-level national environmental research institution. Established in 1978, CRAES leads applied research on environmental pollution control, ecological protection, and environmental standards development. It provides critical technical support for national environmental management decisions, operates key environmental monitoring programs, and maintains authoritative environmental databases. CRAES has developed and revised hundreds of national environmental standards and technical guidelines, including those for water pollution control, air quality, soil remediation, and solid waste management. The academy is responsible for China's national ecological function zoning, environmental capacity assessments, and supporting major environmental policy documents including the Five-Year Plans for ecological environment protection.",
+    "zh": "中国环境科学研究院（环科院）隶属生态环境部，是国家最高级别的环境研究机构，1978年建立。环科院在环境污染治理、生态保护和环境标准制定等应用研究领域处于全国领先地位，为国家环境管理决策提供关键技术支撑，运营重要的环境监测项目，维护权威环境数据库。环科院主持制修订数百项国家环境标准和技术规范，涵盖水污染控制、空气质量、土壤修复和固体废物管理。研究院负责全国生态功能区划、环境容量评估工作，并为生态环境保护五年规划等重要环境政策文件提供技术支持。"
+  },
+  "website": "https://www.craes.cn",
+  "data_url": "https://www.craes.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "environment",
+    "science",
+    "policy"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国环境科学研究院",
+    "CRAES",
+    "Chinese Research Academy of Environmental Sciences",
+    "环境污染",
+    "environmental pollution",
+    "生态保护",
+    "ecological protection",
+    "环境标准",
+    "environmental standards",
+    "水污染",
+    "water pollution",
+    "空气质量",
+    "air quality",
+    "土壤修复",
+    "soil remediation",
+    "固体废物",
+    "solid waste",
+    "生态功能区划",
+    "ecological function zoning",
+    "环境容量",
+    "environmental capacity",
+    "生态环境部",
+    "Ministry of Ecology and Environment",
+    "环境监测",
+    "environmental monitoring",
+    "污染控制",
+    "pollution control",
+    "环境政策",
+    "environmental policy",
+    "五年规划",
+    "Five-Year Plan"
+  ],
+  "data_content": {
+    "en": [
+      "Environmental standards and technical guidelines: hundreds of national environmental standards (GB/HJ series) covering water, air, soil, noise, and solid waste developed or co-developed by CRAES",
+      "Environmental capacity assessments: national and regional estimates of pollutant carrying capacity for major river basins, air sheds, and soil environments",
+      "Ecological function zoning data: national ecological function zone maps, ecosystem service evaluations, and biodiversity protection area delineations",
+      "Water environment research data: datasets on river and lake water quality, sediment contamination, aquatic ecosystem health assessments, and pollution source inventories",
+      "Soil and groundwater pollution data: contaminated site surveys, remediation technology assessments, and national soil pollution status reports",
+      "Air pollution control research: emission factor databases, source apportionment studies, atmospheric dispersion modeling data, and control technology effectiveness evaluations",
+      "Solid waste and hazardous materials: waste characterization data, disposal technology assessments, and industrial hazardous waste inventories",
+      "Environmental health risk assessments: exposure pathway studies, toxicological reference data for Chinese populations, and environmental health risk evaluation frameworks"
+    ],
+    "zh": [
+      "环境标准和技术规范：环科院主持或参与制定数百项国家环境标准（GB/HJ系列），涵盖水、气、土、噪声和固体废物",
+      "环境容量评估：主要流域、大气区和土壤环境的全国及区域污染物承载能力评估",
+      "生态功能区划数据：全国生态功能区划图、生态系统服务价值评估和生物多样性保护区划定",
+      "水环境研究数据：河湖水质、底泥污染、水生生态系统健康评估和污染源清单",
+      "土壤和地下水污染数据：污染地块调查、修复技术评估和全国土壤污染状况报告",
+      "大气污染控制研究：排放因子数据库、来源解析研究、大气扩散模型数据和控制技术效果评估",
+      "固体废物和危险化学品：废物特征化数据、处置技术评估和工业危险废物清单",
+      "环境健康风险评估：暴露途径研究、中国人群毒理学参考数据和环境健康风险评估框架"
+    ]
+  }
+}


### PR DESCRIPTION
## 新增中国权威数据源 · 上午批次 · 2026-04-28

本次新增5个中国权威数据源，全部通过ID去重、域名去重、黑名单检查和网站可访问性验证。

### 新增数据源

| ID | 机构 | 网站 | 类型 | 领域 |
|---|---|---|---|---|
| china-imcas | 中国科学院微生物研究所 | im.cas.cn | research | biology/health/science |
| china-craes | 中国环境科学研究院 | craes.cn | research | environment/science/policy |
| china-cpma | 中华预防医学会 | cpma.org.cn | research | health/science/social |
| china-cisri | 中国钢研科技集团有限公司 | cisri.com.cn | research | industry/science/technology |
| china-ibcas | 中国科学院植物研究所 | ibcas.ac.cn | research | biology/environment/science |

### 验证清单
- [x] ID去重（grep /tmp/all-source-ids.txt）
- [x] 域名去重（grep /tmp/all-source-websites.txt）
- [x] 黑名单检查（check-blacklist.sh）
- [x] website URL可访问（HTTP 200）
- [x] 网站title与机构名吻合
- [x] data_url使用根路径（子路径均不可达）
- [x] `make check` 验证通过（545个ID全部唯一）
- [x] data_content 为数组格式
- [x] domains 使用连字符
- [x] authority_level 合规
- [x] 无 api_docs 字段
- [x] country = CN，geographic_scope = national