### PR TITLE
feat: add 5 China authoritative data sources (2026-04-29 AM)

### DIFF
--- a/firstdata/sources/china/finance/china-iamac.json
+++ b/firstdata/sources/china/finance/china-iamac.json
@@ -1,0 +1,72 @@
+{
+  "id": "china-iamac",
+  "name": {
+    "en": "China Association of Banking and Insurance Asset Management",
+    "zh": "中国银行保险资产管理业协会"
+  },
+  "description": {
+    "en": "The China Association of Banking and Insurance Asset Management (IAMAC) is a national industry self-regulatory organization established in 2021 under the supervision of the National Financial Regulatory Administration (NFRA, formerly CBIRC). IAMAC represents and serves wealth management subsidiaries of commercial banks, insurance asset management companies, and related financial institutions engaged in asset management business in China. The association publishes industry statistical reports, research white papers, regulatory compliance guidelines, and market data on China's banking and insurance asset management sector. IAMAC maintains data on the scale, structure, and performance of wealth management products (理财产品), insurance asset management products, and the aggregate asset management business across its member institutions. It is a key source for understanding the structure and development of China's non-securities asset management industry, which manages over 60 trillion yuan in assets.",
+    "zh": "中国银行保险资产管理业协会（IAMAC）成立于2021年，是在国家金融监督管理总局（原银保监会）监督指导下成立的全国性行业自律组织。协会代表并服务于商业银行理财子公司、保险资产管理公司及从事资产管理业务的相关金融机构。协会发布行业统计报告、研究白皮书、监管合规指引和中国银行保险资产管理行业市场数据。IAMAC维护会员机构理财产品、保险资管产品及资产管理业务总体规模、结构和绩效数据，是了解中国非证券类资产管理行业结构和发展的重要数据来源，该行业管理资产规模超60万亿元人民币。"
+  },
+  "website": "https://www.iamac.org.cn",
+  "data_url": "https://www.iamac.org.cn",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "finance",
+    "economics"
+  ],
+  "update_frequency": "quarterly",
+  "tags": [
+    "中国银行保险资产管理业协会",
+    "IAMAC",
+    "银行理财",
+    "bank wealth management",
+    "理财子公司",
+    "wealth management subsidiary",
+    "保险资产管理",
+    "insurance asset management",
+    "资产管理",
+    "asset management",
+    "理财产品",
+    "wealth management products",
+    "国家金融监督管理总局",
+    "NFRA",
+    "CBIRC",
+    "银保监会",
+    "行业统计",
+    "industry statistics",
+    "自律组织",
+    "self-regulatory organization",
+    "资管新规",
+    "asset management regulation",
+    "净值型产品",
+    "net asset value products",
+    "信托",
+    "trust",
+    "债券投资",
+    "bond investment",
+    "非标资产",
+    "non-standard assets"
+  ],
+  "data_content": {
+    "en": [
+      "Banking wealth management industry statistics: quarterly and annual reports on the total scale of wealth management products issued by commercial banks and their wealth management subsidiaries, including product type breakdown (fixed-income, equity, mixed), maturity structure, and investor categories",
+      "Insurance asset management industry data: aggregate data on insurance funds allocation across different asset classes (bonds, equities, real estate, alternative investments), investment returns, and risk exposure of insurance asset management companies",
+      "Market research white papers: in-depth industry research reports covering market development trends, regulatory impact analysis, product innovation, ESG investment in asset management, and cross-border investment data for the banking and insurance asset management sector",
+      "Regulatory compliance guidelines: industry self-regulatory guidelines, business conduct standards, and compliance reference materials for member institutions on wealth management product design, risk disclosure, investor suitability assessment, and information disclosure",
+      "Product registration and information disclosure data: aggregated data from the industry product registration system covering issuance scale, product performance, fee structures, and underlying asset information for bank wealth management and insurance asset management products",
+      "Investor structure and behavior data: analysis of wealth management product investor profiles, investment preferences, risk tolerance distribution, and market trends in Chinese retail and institutional investor participation in the non-securities asset management market"
+    ],
+    "zh": [
+      "银行理财行业统计：商业银行及其理财子公司发行理财产品总规模季度和年度报告，包括产品类型细分（固收类、权益类、混合类）、期限结构和投资者类别",
+      "保险资管行业数据：保险资金在不同资产类别（债券、股票、房地产、另类投资）的配置总量数据、投资收益和保险资产管理公司风险敞口",
+      "市场研究白皮书：涵盖市场发展趋势、监管影响分析、产品创新、资管领域ESG投资和银行保险资产管理跨境投资数据的深度行业研究报告",
+      "监管合规指引：理财产品设计、风险信息披露、投资者适当性评估和信息公示方面的行业自律指引、业务行为准则和会员机构合规参考材料",
+      "产品登记和信息披露数据：行业产品登记系统汇总数据，涵盖银行理财和保险资管产品的发行规模、产品业绩、费率结构和底层资产信息",
+      "投资者结构和行为数据：中国零售和机构投资者参与非证券类资产管理市场的理财产品投资者画像、投资偏好、风险承受分布和市场趋势分析"
+    ]
+  }
+}

--- a/firstdata/sources/china/governance/china-nnsa.json
+++ b/firstdata/sources/china/governance/china-nnsa.json
@@ -1,0 +1,78 @@
+{
+  "id": "china-nnsa",
+  "name": {
+    "en": "National Nuclear Safety Administration",
+    "zh": "国家核安全局"
+  },
+  "description": {
+    "en": "The National Nuclear Safety Administration (NNSA) of China is the national regulatory authority responsible for the safety supervision and management of nuclear and radiation safety, operating as a functional department under the Ministry of Ecology and Environment (MEE). Established in 1984, NNSA regulates the licensing, construction, operation, and decommissioning of nuclear power plants, research reactors, nuclear fuel cycle facilities, and radioactive waste management facilities across China. NNSA publishes China's nuclear safety regulations, technical guidelines, licensing decisions, and annual nuclear safety reports. It maintains registries of licensed nuclear installations, radiation sources, and radioactive waste repositories, and publishes environmental radiation monitoring data from nuclear facilities. NNSA is China's competent authority under the Convention on Nuclear Safety and cooperates with the International Atomic Energy Agency (IAEA) on nuclear safety standards and peer reviews.",
+    "zh": "国家核安全局（NNSA）是中国负责核与辐射安全监督管理的国家监管机构，作为生态环境部的职能部门运行。NNSA成立于1984年，负责对中国核电站、研究堆、核燃料循环设施和放射性废物管理设施的许可、建设、运行和退役实施监管。国家核安全局发布中国核安全法规、技术导则、许可决定和年度核安全报告，维护持证核设施、放射源和放射性废物库的登记注册，并发布核设施周边环境辐射监测数据。NNSA是《核安全公约》下的中国主管当局，与国际原子能机构（IAEA）在核安全标准和同行评审方面开展合作。"
+  },
+  "website": "http://nnsa.mee.gov.cn",
+  "data_url": "http://nnsa.mee.gov.cn",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "energy",
+    "environment",
+    "science",
+    "governance"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "国家核安全局",
+    "NNSA",
+    "核安全",
+    "nuclear safety",
+    "辐射安全",
+    "radiation safety",
+    "核电站",
+    "nuclear power plant",
+    "核监管",
+    "nuclear regulation",
+    "放射性废物",
+    "radioactive waste",
+    "核燃料",
+    "nuclear fuel",
+    "核许可证",
+    "nuclear license",
+    "环境辐射监测",
+    "environmental radiation monitoring",
+    "核安全法规",
+    "nuclear safety regulations",
+    "核安全导则",
+    "nuclear safety guides",
+    "核设施",
+    "nuclear installations",
+    "放射源",
+    "radiation sources",
+    "生态环境部",
+    "Ministry of Ecology and Environment",
+    "MEE",
+    "IAEA",
+    "核安全公约",
+    "Convention on Nuclear Safety",
+    "研究堆",
+    "research reactor"
+  ],
+  "data_content": {
+    "en": [
+      "Nuclear safety regulations and technical guidelines: comprehensive collection of China's HAF (nuclear safety) regulatory framework documents, technical safety guidelines (HAD series), and regulatory basis documents for nuclear power plants, research reactors, and fuel cycle facilities",
+      "Nuclear facility licensing registry: database of licensed and pending nuclear installations in China, including nuclear power units (operational, under construction, decommissioned), research reactors, uranium processing facilities, and radioactive waste repositories",
+      "Annual nuclear safety reports: comprehensive annual assessment of China's nuclear safety performance, including safety inspection results, events and incidents statistics, radioactive release data, and regulatory enforcement actions",
+      "Environmental radiation monitoring data: radiation dose rate, radioactivity concentration in air, water, and soil from monitoring networks around nuclear power plants and other nuclear facilities, supporting public transparency and safety oversight",
+      "Radiation source and radioactive waste registries: national registries of sealed and unsealed radioactive sources, radiation-emitting devices, and radioactive waste storage facilities subject to regulatory control",
+      "Nuclear event and incident reports: classified and public reports on nuclear and radiological events at Chinese nuclear facilities, including INES-rated incidents, near-misses, and safety-significant events reported under national and international obligations"
+    ],
+    "zh": [
+      "核安全法规和技术导则：中国HAF（核安全）监管框架文件、技术安全导则（HAD系列）和核电站、研究堆、燃料循环设施监管基础文件综合集",
+      "核设施许可证注册库：中国持证和待审核设施数据库，包括核电机组（运行中、在建、退役）、研究堆、铀处理设施和放射性废物库",
+      "年度核安全报告：中国核安全绩效年度综合评估，包括安全检查结果、事件和事故统计、放射性排放数据和监管执法行动",
+      "环境辐射监测数据：核电站和其他核设施周边监测网络的辐射剂量率、空气、水和土壤中放射性活度浓度数据，支持公众透明度和安全监管",
+      "放射源和放射性废物登记注册：国家监管范围内的密封和非密封放射源、辐射装置和放射性废物贮存设施国家注册库",
+      "核事件和事故报告：中国核设施核与辐射事件的分级和公开报告，包括INES评级事件、未遂事件和依据国家及国际义务报告的安全重要事件"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-cabr.json
+++ b/firstdata/sources/china/research/china-cabr.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-cabr",
+  "name": {
+    "en": "China Academy of Building Research",
+    "zh": "中国建筑科学研究院有限公司"
+  },
+  "description": {
+    "en": "The China Academy of Building Research (CABR) is China's top comprehensive research and development institution in the field of engineering construction, founded in 1953 and formerly under the Ministry of Housing and Urban-Rural Development (MOHURD). CABR is the primary technical body responsible for drafting and revising China's national and industry standards for construction, including the national Building Code (GB 50010), Seismic Design Code, Energy Efficiency Standards, and Fire Protection Code. The academy operates multiple national laboratories and testing centers, and maintains authoritative databases on building energy performance, structural safety, fire resistance ratings, and building materials quality. CABR has led the development of China's green building evaluation standard (GB/T 50378) and publishes research on building technology, energy efficiency, indoor environment quality, and smart buildings. It is the national technical authority that supports MOHURD policies and urban-rural construction regulation.",
+    "zh": "中国建筑科学研究院有限公司（中国建研院，CABR）成立于1953年，是中国工程建设领域顶级综合性科学研究开发机构，原属住房和城乡建设部管理。CABR是负责起草和修订中国建筑国家标准和行业标准的主要技术机构，包括《混凝土结构设计标准》（GB 50010）、抗震设计规范、建筑节能标准和消防规范。学院运营多个国家实验室和检测中心，维护建筑能效、结构安全、防火性能等级和建筑材料质量权威数据库。CABR主导制定了中国绿色建筑评价标准（GB/T 50378），并发布建筑技术、节能、室内环境质量和智慧建筑研究成果，是支撑住建部政策和城乡建设监管的国家技术权威机构。"
+  },
+  "website": "https://www.cabr.cn",
+  "data_url": "https://www.cabr.cn",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "construction",
+    "engineering",
+    "science",
+    "environment"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国建筑科学研究院",
+    "CABR",
+    "建筑标准",
+    "construction standards",
+    "建筑规范",
+    "building code",
+    "抗震设计",
+    "seismic design",
+    "建筑节能",
+    "building energy efficiency",
+    "绿色建筑",
+    "green building",
+    "GB 50010",
+    "GB/T 50378",
+    "结构安全",
+    "structural safety",
+    "防火性能",
+    "fire resistance",
+    "建筑材料",
+    "building materials",
+    "室内环境",
+    "indoor environment",
+    "智慧建筑",
+    "smart buildings",
+    "住房和城乡建设部",
+    "MOHURD",
+    "国家实验室",
+    "national laboratory",
+    "工程建设",
+    "engineering construction",
+    "城乡建设",
+    "urban-rural construction"
+  ],
+  "data_content": {
+    "en": [
+      "Construction standards and codes database: full texts and technical interpretations of major national and industry standards drafted by CABR, including structural design codes (GB 50010 concrete, GB 50017 steel), seismic design standards, fire protection codes, and building energy efficiency standards",
+      "Building energy performance data: research datasets on energy consumption benchmarks for residential and public buildings across different climate zones in China, supporting the implementation of mandatory energy efficiency standards and green building certification",
+      "Structural safety testing results: laboratory test data on concrete, steel, composite structures, and building materials under static, dynamic, and extreme loading conditions, underpinning national standard development",
+      "Green building evaluation data: assessment results from China's Green Building Label certification program (GB/T 50378), including energy, water, material, indoor environment, and site management performance indicators for certified buildings",
+      "Indoor environment quality research: datasets on indoor air quality, thermal comfort, acoustics, and lighting in Chinese buildings, informing national health and safety standards for construction",
+      "Construction technology research outputs: technical reports, engineering case studies, and data on innovative construction technologies including prefabricated buildings, BIM applications, and smart building systems published by CABR research institutes"
+    ],
+    "zh": [
+      "建筑标准和规范数据库：CABR起草的主要国家标准和行业标准全文及技术解读，包括结构设计规范（GB 50010混凝土、GB 50017钢结构）、抗震设计标准、消防规范和建筑节能标准",
+      "建筑能效数据：中国不同气候区住宅和公共建筑能耗基准研究数据集，支持强制性节能标准实施和绿色建筑认证",
+      "结构安全测试数据：混凝土、钢材、组合结构和建筑材料在静态、动态和极端荷载条件下的实验室测试数据，支撑国家标准制定",
+      "绿色建筑评估数据：中国绿色建筑标识认证项目（GB/T 50378）的评估结果，包括认证建筑的能源、水资源、材料、室内环境和场地管理绩效指标",
+      "室内环境质量研究：中国建筑室内空气质量、热舒适度、声学和照明数据集，为建筑健康与安全国家标准提供依据",
+      "建筑技术研究成果：CABR各研究院所发布的技术报告、工程案例研究以及装配式建筑、BIM应用和智慧建筑系统等创新建筑技术数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/technology/china-beidou.json
+++ b/firstdata/sources/china/technology/china-beidou.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-beidou",
+  "name": {
+    "en": "BeiDou Navigation Satellite System",
+    "zh": "北斗卫星导航系统"
+  },
+  "description": {
+    "en": "The BeiDou Navigation Satellite System (BDS) is China's independently developed global satellite navigation system, managed by the China Satellite Navigation Office (CSNO) under the State Council. Fully operational since 2020 with 35 satellites, BDS is one of the four global navigation systems recognized by the United Nations and provides positioning, navigation, timing, and short message communication services worldwide. The official website publishes signal interface control documents, system performance standards, open service performance reports, satellite constellation status, and technical specifications for receivers and applications. BDS data are essential for precision agriculture, surveying, transportation, disaster relief, and maritime navigation. The system achieves positioning accuracy of ≤1.5m horizontal globally (≤1m in Asia-Pacific) and supports high-precision augmented services for centimeter-level accuracy.",
+    "zh": "北斗卫星导航系统（BDS）是中国自主研发的全球卫星导航系统，由国务院下设的中国卫星导航系统管理办公室负责运营。北斗系统于2020年全面建成，部署35颗卫星，是联合国认可的四大全球导航系统之一，向全球用户提供定位、导航、授时和短报文通信服务。官网发布信号接口控制文件、系统性能标准、开放服务性能评估报告、卫星星座状态和接收机及应用技术规范。北斗数据广泛应用于精准农业、测量测绘、交通运输、抗灾救灾和海上导航等领域。系统全球水平定位精度≤1.5米（亚太地区≤1米），并支持厘米级高精度增强服务。"
+  },
+  "website": "http://www.beidou.gov.cn",
+  "data_url": "http://www.beidou.gov.cn",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "global",
+  "domains": [
+    "technology",
+    "science",
+    "infrastructure"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "北斗",
+    "BeiDou",
+    "BDS",
+    "卫星导航",
+    "satellite navigation",
+    "GNSS",
+    "全球导航卫星系统",
+    "global navigation satellite system",
+    "定位",
+    "positioning",
+    "导航",
+    "navigation",
+    "授时",
+    "timing",
+    "短报文",
+    "short message communication",
+    "信号接口控制文件",
+    "interface control document",
+    "ICD",
+    "系统性能",
+    "system performance",
+    "卫星星座",
+    "satellite constellation",
+    "精准定位",
+    "precision positioning",
+    "高精度增强",
+    "high-precision augmentation",
+    "中国卫星导航系统管理办公室",
+    "CSNO",
+    "精准农业",
+    "precision agriculture",
+    "联合国",
+    "United Nations"
+  ],
+  "data_content": {
+    "en": [
+      "Signal interface control documents (ICD): detailed technical specifications for BDS open service signals (B1I, B1C, B2a, B2b, B3I), including signal structure, modulation schemes, navigation message formats, and ranging code parameters for receiver developers and researchers",
+      "System performance reports: annual and quarterly open service performance assessment reports covering positioning accuracy, availability, continuity, and integrity metrics for the global and Asia-Pacific service areas",
+      "Satellite constellation status: real-time and historical information on the operational status of BDS satellites including GEO, IGSO, and MEO satellites, health status, and signal-in-space range error (SISRE) data",
+      "Technical standards and specifications: national standards and industry standards for BDS receivers, applications, testing methods, and compatibility with other GNSS systems (GPS, GLONASS, Galileo)",
+      "Official announcements and policy documents: notices of satellite maneuvers, signal outages, system updates, new service launches, and policy documents governing BDS technology export and application development",
+      "Application development resources: technical reference materials, development kits documentation, and guidelines for integrating BDS into smart transportation, precision agriculture, maritime navigation, and emergency response systems"
+    ],
+    "zh": [
+      "信号接口控制文件（ICD）：北斗开放服务信号（B1I、B1C、B2a、B2b、B3I）的详细技术规范，包括信号结构、调制方案、导航电文格式和测距码参数，供接收机开发商和研究人员使用",
+      "系统性能报告：年度和季度开放服务性能评估报告，涵盖全球和亚太服务区的定位精度、可用性、连续性和完整性指标",
+      "卫星星座状态：北斗GEO、IGSO和MEO卫星的实时和历史运行状态信息，包括卫星健康状态和空间信号测距误差（SISRE）数据",
+      "技术标准和规范：北斗接收机、应用、测试方法及与其他GNSS系统（GPS、GLONASS、Galileo）兼容性的国家标准和行业标准",
+      "官方公告和政策文件：卫星机动、信号中断、系统更新、新服务开通的通知，以及北斗技术出口和应用开发管理政策文件",
+      "应用开发资源：将北斗集成到智慧交通、精准农业、海上导航和应急响应系统的技术参考资料、开发套件文档和集成指南"
+    ]
+  }
+}

--- a/firstdata/sources/china/technology/standards/china-csa.json
+++ b/firstdata/sources/china/technology/standards/china-csa.json
@@ -1,0 +1,78 @@
+{
+  "id": "china-csa",
+  "name": {
+    "en": "China Association for Standardization",
+    "zh": "中国标准化协会"
+  },
+  "description": {
+    "en": "The China Association for Standardization (CAS/CSA) is a national non-governmental industry organization founded in 1978, operating under the guidance of the State Administration for Market Regulation (SAMR) and the Standardization Administration of China (SAC). CSA is a key platform for voluntary standards development, standards education and promotion, and international standardization cooperation in China. The association develops group standards (团体标准) across industry sectors, provides standardization consulting and certification services, and organizes technical committees for emerging technology areas including smart manufacturing, e-commerce, carbon neutrality, and data governance. CSA publishes research reports on China's standardization policy landscape, group standards directories, and industry-specific standardization roadmaps. It interfaces with ISO, IEC, and ITU for Chinese participation in international standards development and serves as a bridge between government standardization agencies and enterprise standards practices.",
+    "zh": "中国标准化协会（CSA）成立于1978年，是在国家市场监督管理总局和国家标准化管理委员会指导下运行的全国性非政府行业组织。CSA是中国自愿性标准制定、标准教育和推广以及国际标准化合作的重要平台。协会在智能制造、电子商务、碳中和和数据治理等新兴技术领域跨行业制定团体标准，提供标准化咨询和认证服务，并组织技术委员会。CSA发布中国标准化政策研究报告、团体标准目录和行业标准化路线图，对接ISO、IEC和ITU，推动中国参与国际标准制定，是政府标准化机构与企业标准实践的重要桥梁。"
+  },
+  "website": "https://www.china-cas.org",
+  "data_url": "https://www.china-cas.org",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "technology",
+    "industry",
+    "science",
+    "economics"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国标准化协会",
+    "CSA",
+    "China Association for Standardization",
+    "标准化",
+    "standardization",
+    "团体标准",
+    "group standards",
+    "自愿性标准",
+    "voluntary standards",
+    "国家标准化管理委员会",
+    "SAC",
+    "国家市场监督管理总局",
+    "SAMR",
+    "ISO",
+    "IEC",
+    "ITU",
+    "国际标准化",
+    "international standardization",
+    "智能制造",
+    "smart manufacturing",
+    "碳中和",
+    "carbon neutrality",
+    "数据治理",
+    "data governance",
+    "标准化政策",
+    "standardization policy",
+    "标准化路线图",
+    "standardization roadmap",
+    "电子商务",
+    "e-commerce",
+    "标准化咨询",
+    "standardization consulting",
+    "新兴技术",
+    "emerging technology"
+  ],
+  "data_content": {
+    "en": [
+      "Group standards (团体标准) directory and database: searchable registry of voluntary group standards developed by CSA and its technical committees across sectors including smart manufacturing, green economy, digital economy, logistics, and consumer goods, with standard status, applicability, and revision history",
+      "Standards search and access platform: query interface for China's national standards (GB/T), industry standards, and group standards with cross-reference to international standards equivalents (ISO, IEC, ASTM), supporting standards research and compliance work",
+      "Standardization policy research reports: annual and thematic reports on China's standardization strategy, reform progress, international standards adoption rates, and policy developments in key sectors such as AI governance, carbon neutrality, and digital infrastructure",
+      "International standards participation data: records of Chinese expert participation in ISO and IEC technical committees, Chinese-led international standard projects, and adopted international standards incorporated into China's national standards system",
+      "Standards education and certification data: training curriculum materials, examination statistics for standardization professionals, and data on certified enterprise standardization managers and national model enterprises for standardization",
+      "Industry standardization roadmaps: technology and sector-specific standardization roadmaps co-developed with industry partners covering emerging fields such as hydrogen energy, new energy vehicles, industrial internet, and blockchain applications in China"
+    ],
+    "zh": [
+      "团体标准目录和数据库：CSA及其技术委员会在智能制造、绿色经济、数字经济、物流和消费品等领域制定的自愿性团体标准可检索注册库，含标准状态、适用范围和修订历史",
+      "标准检索和查询平台：中国国家标准（GB/T）、行业标准和团体标准查询界面，交叉引用ISO、IEC、ASTM等国际标准对应关系，支持标准研究和合规工作",
+      "标准化政策研究报告：中国标准化战略、改革进展、国际标准采用率年度和专题报告，以及人工智能治理、碳中和和数字基础设施等重点领域政策动态",
+      "国际标准参与数据：中国专家参与ISO和IEC技术委员会的记录、中国主导的国际标准项目，以及纳入中国国家标准体系的已采用国际标准",
+      "标准化教育和认证数据：标准化专业人员培训课程材料、考试统计数据，以及认证企业标准化管理者和国家标准化示范企业数据",
+      "行业标准化路线图：与行业伙伴联合制定的技术和领域专属标准化路线图，涵盖氢能、新能源汽车、工业互联网和区块链在中国的应用等新兴领域"
+    ]
+  }
+}


### PR DESCRIPTION
## 新增5个中国权威数据源（2026-04-29 上午批次）

### 新增数据源

| ID | 中文名 | 机构类型 | 领域 |
|---|---|---|---|
| china-beidou | 北斗卫星导航系统 | 政府 | technology, science, infrastructure |
| china-cabr | 中国建筑科学研究院有限公司 | 研究机构 | construction, engineering, science |
| china-nnsa | 国家核安全局 | 政府 | energy, environment, science |
| china-iamac | 中国银行保险资产管理业协会 | 行业协会 | finance, economics |
| china-csa | 中国标准化协会 | 行业协会 | technology, industry, science |

### 数据源说明

- **china-beidou**: 中国独立研制的全球卫星导航系统，发布信号接口控制文件、系统性能报告和卫星星座状态数据
- **china-cabr**: 国家建筑工程领域顶级研究机构，GB 50010等重要建筑标准主要起草单位，维护建筑节能、绿色建筑等权威数据
- **china-nnsa**: 核与辐射安全国家监管机构，发布核设施许可注册、年度核安全报告和环境辐射监测数据
- **china-iamac**: 银行理财和保险资管行业自律组织，发布行业统计报告和市场数据，覆盖超60万亿元资产管理规模
- **china-csa**: 自愿性团体标准制定平台，对接ISO/IEC国际标准化，发布标准化政策研究报告和行业路线图

### 验证清单
- [x] ID唯一性检查（双重去重：ID + 网站域名）
- [x] 黑名单检查
- [x] website URL验证（全部返回 200/301/302）
- [x] data_url验证（深链404/405时回退根路径）
- [x] 网站title核实与机构名一致
- [x] Schema验证通过
- [x] data_content为数组格式
- [x] domains使用连字符
- [x] authority_level合法值
- [x] country使用ISO 3166-1 alpha-2 (CN)