### PR TITLE
feat: add 5 China authoritative data sources (2026-04-29 PM)

### DIFF
--- a/firstdata/sources/china/governance/china-ggzy.json
+++ b/firstdata/sources/china/governance/china-ggzy.json
@@ -1,0 +1,75 @@
+{
+  "id": "china-ggzy",
+  "name": {
+    "en": "China National Public Resources Trading Platform",
+    "zh": "全国公共资源交易平台"
+  },
+  "description": {
+    "en": "The China National Public Resources Trading Platform (GGZY, 全国公共资源交易平台) is the authoritative national government portal for public resources trading, administered by the National Development and Reform Commission (NDRC) in conjunction with the State Administration for Market Regulation and other central agencies. The platform aggregates and discloses transaction data from public resource auctions and procurements across China, including engineering construction project bidding, government procurement, state-owned property rights and assets transfers, mineral rights auctions, and other public resource trading activities. As the designated national unified trading service platform mandated by the State Council, GGZY provides comprehensive transparency data on public resource market transactions, bidding results, contract awards, and participant information, making it the primary reference for public procurement market analysis, anti-corruption monitoring, and policy evaluation in China.",
+    "zh": "全国公共资源交易平台（GGZY）是国家发展和改革委员会联合市场监管总局等中央机构主管的权威国家政府门户，专门用于公共资源交易公示。平台汇聚并公开全国公共资源拍卖和采购的交易数据，涵盖工程建设项目招标、政府采购、国有产权及资产转让、矿业权拍卖及其他公共资源交易活动。作为国务院指定的国家统一交易服务平台，GGZY提供公共资源市场交易、招标结果、合同授予和参与方信息的全面公示数据，是中国公共采购市场分析、廉政监察和政策评估的主要数据来源。"
+  },
+  "website": "https://www.ggzy.gov.cn/",
+  "data_url": "https://www.ggzy.gov.cn/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "governance",
+    "economics",
+    "finance"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "全国公共资源交易平台",
+    "GGZY",
+    "public resources trading",
+    "公共资源交易",
+    "政府采购",
+    "government procurement",
+    "工程招标",
+    "engineering bidding",
+    "招投标",
+    "bid tendering",
+    "国有资产",
+    "state-owned assets",
+    "产权交易",
+    "property rights trading",
+    "矿业权",
+    "mineral rights",
+    "国家发展改革委",
+    "NDRC",
+    "透明度",
+    "transparency",
+    "反腐",
+    "anti-corruption",
+    "合同授予",
+    "contract award",
+    "采购公告",
+    "procurement announcement",
+    "中标结果",
+    "bid results"
+  ],
+  "data_content": {
+    "en": [
+      "Engineering construction project bidding: bid notices, bid results, and contract award announcements for infrastructure and construction projects across all provinces",
+      "Government procurement: procurement announcements, evaluation results, and contract awards for goods, services, and works purchased by government entities",
+      "State-owned property rights transfers: listings and transaction results for state-owned enterprises and assets transferred through public trading processes",
+      "Mineral rights auctions: auction notices and results for exploration and mining rights across coal, metals, oil and gas, and other minerals",
+      "Land use rights trading: public land auction results and transaction data (linked to land market)",
+      "Market participant information: bidder registration data, qualification records, and performance history for companies participating in public resource transactions",
+      "Transaction volume statistics: aggregate data on total public resource trading volume, deal counts, and market activity by region and sector",
+      "Supervision and compliance data: records of bidding irregularities, debarment decisions, and compliance enforcement actions"
+    ],
+    "zh": [
+      "工程建设项目招标：全国各省基础设施和建设项目的招标公告、招标结果及合同授予公示",
+      "政府采购：政府实体采购货物、服务和工程的采购公告、评标结果和合同授予公示",
+      "国有产权转让：通过公开交易流程转让的国有企业和国有资产挂牌信息及成交结果",
+      "矿业权拍卖：煤炭、金属、油气及其他矿产探矿权和采矿权的拍卖公告及成交结果",
+      "土地使用权交易：公开土地拍卖结果和交易数据（与土地市场联通）",
+      "市场主体信息：参与公共资源交易企业的投标人登记数据、资质记录和履约历史",
+      "交易量统计：按地区和行业分类的公共资源交易总量、成交笔数和市场活跃度汇总数据",
+      "监督与合规数据：串标违规记录、不良行为认定及合规执法措施记录"
+    ]
+  }
+}

--- a/firstdata/sources/china/governance/china-pkulaw.json
+++ b/firstdata/sources/china/governance/china-pkulaw.json
@@ -1,0 +1,84 @@
+{
+  "id": "china-pkulaw",
+  "name": {
+    "en": "PKU Law (Peking University Law Database)",
+    "zh": "北大法宝"
+  },
+  "description": {
+    "en": "PKU Law (Peking University Law, 北大法宝) is China's most comprehensive legal database, operated by the Institute of Legal Information of Peking University Law School. It aggregates the full text of Chinese laws, administrative regulations, judicial interpretations, local regulations, court judgments, legal journals, and legislative history from 1949 to the present. The database covers over 10 million legal documents including all national legislation promulgated by the National People's Congress (NPC), State Council regulations, ministry-level normative documents, provincial and municipal local laws, Supreme People's Court and Supreme People's Procuratorate judicial interpretations, and millions of court verdicts. PKU Law is the authoritative legal reference for legal practitioners, judiciary officials, government agencies, corporations, academic researchers, and law schools across China. The database is continuously updated with new legislative developments and court decisions, making it the primary tool for tracking China's evolving legal framework.",
+    "zh": "北大法宝（北京大学法律信息中心）是中国最权威、最全面的法律数据库，由北京大学法学院法律信息中心运营。数据库收录了1949年至今的中国法律、行政法规、司法解释、地方法规、法院判决、法学期刊及立法历史全文，覆盖超过1000万份法律文件，包括全国人民代表大会颁布的国家立法、国务院法规、部委规范性文件、省市地方法规、最高人民法院和最高人民检察院司法解释，以及数百万份裁判文书。北大法宝是全国法律从业者、司法人员、政府机关、企业法务、学术研究者和法学院校的权威法律参考工具，持续更新最新立法动态和判决信息，是追踪中国法制演进的核心平台。"
+  },
+  "website": "https://www.pkulaw.com/",
+  "data_url": "https://www.pkulaw.com/law",
+  "api_url": null,
+  "authority_level": "research",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "governance",
+    "law",
+    "policy"
+  ],
+  "update_frequency": "daily",
+  "tags": [
+    "北大法宝",
+    "PKU Law",
+    "Peking University Law",
+    "中国法律",
+    "Chinese law",
+    "法律数据库",
+    "legal database",
+    "法规",
+    "regulations",
+    "司法解释",
+    "judicial interpretations",
+    "裁判文书",
+    "court judgments",
+    "地方法规",
+    "local regulations",
+    "立法",
+    "legislation",
+    "全国人大",
+    "NPC",
+    "国务院",
+    "State Council",
+    "法学期刊",
+    "legal journals",
+    "法条",
+    "legal provisions",
+    "行政法规",
+    "administrative regulations",
+    "规范性文件",
+    "normative documents",
+    "法律检索",
+    "legal research",
+    "合规",
+    "compliance"
+  ],
+  "data_content": {
+    "en": [
+      "National legislation: full text of all laws enacted by the National People's Congress (NPC) and its Standing Committee from 1949 to present",
+      "Administrative regulations: State Council regulations, implementation rules, and policy documents",
+      "Judicial interpretations: Supreme People's Court and Supreme People's Procuratorate interpretations, guiding cases, and judicial policies",
+      "Local regulations: provincial, municipal, and special economic zone legislation and government rules",
+      "Ministry-level normative documents: departmental regulations and rules from all central government ministries",
+      "Court judgments: millions of civil, criminal, administrative, and commercial court verdicts at all levels",
+      "Legal journals: full text of major Chinese law reviews and legal academic publications",
+      "Legislative history: revision history, explanatory notes, and comparative analysis of legislative changes",
+      "International treaties: treaties and conventions signed and ratified by China",
+      "Legal Q&A and commentary: expert legal analysis and practice guides"
+    ],
+    "zh": [
+      "国家立法：全国人民代表大会及其常委会自1949年至今颁布的所有法律全文",
+      "行政法规：国务院法规、实施细则及政策文件",
+      "司法解释：最高人民法院和最高人民检察院司法解释、指导性案例及司法政策",
+      "地方法规：省级、市级及经济特区立法和政府规章",
+      "部委规范性文件：各中央部委制定的部门规章和规范性文件",
+      "裁判文书：各级法院民事、刑事、行政及商事裁判文书数百万份",
+      "法学期刊：主要中国法学评论和法律学术出版物全文",
+      "立法历史：法规修订历史、立法说明及法律变迁比较分析",
+      "国际条约：中国签署和批准的条约及国际公约",
+      "法律问答与评注：专家法律分析及实务指南"
+    ]
+  }
+}

--- a/firstdata/sources/china/industry/china-miit-eidc.json
+++ b/firstdata/sources/china/industry/china-miit-eidc.json
@@ -1,0 +1,76 @@
+{
+  "id": "china-miit-eidc",
+  "name": {
+    "en": "MIIT Equipment Industry Development Center",
+    "zh": "工业和信息化部装备工业发展中心"
+  },
+  "description": {
+    "en": "The Equipment Industry Development Center (EIDC) of China's Ministry of Industry and Information Technology (MIIT) is a national-level policy research and data analysis institution specializing in China's equipment manufacturing sector. EIDC tracks and analyzes the development of high-end equipment industries including machine tools, industrial robots, rail transit equipment, aerospace equipment, marine engineering machinery, energy equipment, and agricultural machinery. The center publishes industry analysis reports, equipment manufacturing operation data, enterprise rankings, and policy research outputs that serve as authoritative references for government planning, industry benchmarking, and investment decisions. EIDC data covers production output, market scale, technology advancement indicators, and international competitiveness metrics for China's strategic equipment manufacturing industries, which are central to the Made in China 2025 and dual circulation strategy implementation.",
+    "zh": "工业和信息化部装备工业发展中心（EIDC）是工业和信息化部下属的国家级政策研究与数据分析机构，专注于中国装备制造业发展研究。EIDC追踪和分析机床、工业机器人、轨道交通装备、航空航天装备、海洋工程机械、能源装备和农业机械等高端装备产业发展动态，发布行业分析报告、装备制造业运行数据、企业排名和政策研究成果，是政府规划制定、行业对标和投资决策的权威参考。EIDC数据涵盖中国战略性装备制造产业的生产产出、市场规模、技术进步指标和国际竞争力评估，是「中国制造2025」和双循环战略落实情况的重要数据来源。"
+  },
+  "website": "https://www.miit-eidc.org.cn/",
+  "data_url": "https://www.miit-eidc.org.cn/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "industry",
+    "technology",
+    "economics"
+  ],
+  "update_frequency": "monthly",
+  "tags": [
+    "工业和信息化部装备工业发展中心",
+    "MIIT",
+    "EIDC",
+    "装备制造",
+    "equipment manufacturing",
+    "高端装备",
+    "high-end equipment",
+    "机床",
+    "machine tools",
+    "工业机器人",
+    "industrial robots",
+    "轨道交通",
+    "rail transit equipment",
+    "航空航天装备",
+    "aerospace equipment",
+    "海洋工程",
+    "marine engineering",
+    "农业机械",
+    "agricultural machinery",
+    "中国制造2025",
+    "Made in China 2025",
+    "制造业",
+    "manufacturing",
+    "工业统计",
+    "industrial statistics",
+    "产业分析",
+    "industry analysis",
+    "企业排名",
+    "enterprise rankings"
+  ],
+  "data_content": {
+    "en": [
+      "Equipment manufacturing operation data: monthly and annual output statistics for key equipment categories including machine tools, industrial robots, rail equipment, and energy machinery",
+      "Industry analysis reports: sector assessments covering market scale, growth trends, enterprise concentration, and regional distribution of equipment manufacturing",
+      "Enterprise rankings: performance rankings of major equipment manufacturers by revenue, output, R&D investment, and market share",
+      "Technology advancement indicators: tracking innovation metrics, patent filings, and technology maturity levels across strategic equipment sectors",
+      "Policy research outputs: analysis of domestic and international policies affecting equipment manufacturing competitiveness",
+      "International comparison data: benchmarking China's equipment industry against major manufacturing nations including Germany, Japan, South Korea, and the United States",
+      "Market demand forecasts: projections for downstream industry demand driving equipment purchases in sectors such as energy, transportation, and construction",
+      "Import substitution tracking: progress data on replacing imported equipment with domestically produced alternatives across strategic sectors"
+    ],
+    "zh": [
+      "装备制造业运行数据：机床、工业机器人、轨道装备和能源机械等主要装备类别的月度和年度产量统计",
+      "行业分析报告：涵盖市场规模、增长趋势、企业集中度和装备制造业区域分布的行业评估报告",
+      "企业排名：按营收、产量、研发投入和市场份额对主要装备制造企业进行排名",
+      "技术进步指标：追踪战略性装备领域的创新指标、专利申请和技术成熟度水平",
+      "政策研究成果：影响装备制造竞争力的国内外政策分析",
+      "国际比较数据：中国装备工业与德国、日本、韩国和美国等主要制造大国的横向对比",
+      "市场需求预测：能源、交通运输和建筑等下游产业拉动装备需求的展望预测",
+      "进口替代跟踪：战略领域以国产装备替代进口设备的进展数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/research/china-polar-service.json
+++ b/firstdata/sources/china/research/china-polar-service.json
@@ -1,0 +1,86 @@
+{
+  "id": "china-polar-service",
+  "name": {
+    "en": "China Polar Operations Service Platform (CHINARE Data)",
+    "zh": "中国极地业务服务平台"
+  },
+  "description": {
+    "en": "The China Polar Operations Service Platform (chinare.org.cn) is the official operational data and service platform for China's National Arctic and Antarctic Expeditions (CHINAREs), managed by the Chinese Arctic and Antarctic Administration (CAA) under the Ministry of Natural Resources. The platform provides public access to observational data, expedition records, and scientific datasets collected during China's polar expeditions across Antarctica and the Arctic. China has maintained a continuous presence in Antarctica since 1985, with research stations including Zhongshan Station, Great Wall Station, Kunlun Station, and Taishan Station, plus Yellow River Station in the Arctic (Svalbard). The platform hosts multi-disciplinary polar science data including atmospheric observations, ice and snow data, marine environment monitoring, geological surveys, ecology datasets, and expedition logistics records spanning over 40 years of Chinese polar exploration. This data is critical for global climate change research, sea-level rise assessment, and understanding Earth's cryosphere.",
+    "zh": "中国极地业务服务平台（chinare.org.cn）是中国南北极科学考察（CHINARE）的官方业务数据与服务平台，由自然资源部中国极地研究中心（国家海洋局极地考察办公室）管理。平台向公众提供中国南北极历次科考的观测数据、科考记录和科学数据集。自1985年起，中国在南极建立了中山站、长城站、昆仑站和泰山站，并在北极斯瓦尔巴群岛建立了黄河站，保持长期科学考察。平台汇聚了跨越40余年中国极地探索的多学科极地科学数据，涵盖大气观测、冰雪数据、海洋环境监测、地质调查、生态数据集和科考后勤记录。这些数据对全球气候变化研究、海平面上升评估和地球冰冻圈研究至关重要。"
+  },
+  "website": "https://www.chinare.org.cn/",
+  "data_url": "https://www.chinare.org.cn/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "global",
+  "domains": [
+    "environment",
+    "climate",
+    "ocean",
+    "science"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "中国极地业务服务平台",
+    "CHINARE",
+    "中国南极科学考察",
+    "China Antarctic Expedition",
+    "中国北极科学考察",
+    "China Arctic Expedition",
+    "南极",
+    "Antarctica",
+    "北极",
+    "Arctic",
+    "极地",
+    "polar",
+    "中山站",
+    "Zhongshan Station",
+    "长城站",
+    "Great Wall Station",
+    "昆仑站",
+    "Kunlun Station",
+    "黄河站",
+    "Yellow River Station",
+    "冰川",
+    "glacier",
+    "冰盖",
+    "ice sheet",
+    "海冰",
+    "sea ice",
+    "气候变化",
+    "climate change",
+    "冰冻圈",
+    "cryosphere",
+    "海平面",
+    "sea level",
+    "极地大气",
+    "polar atmosphere",
+    "自然资源部",
+    "Ministry of Natural Resources",
+    "极地科学数据",
+    "polar science data"
+  ],
+  "data_content": {
+    "en": [
+      "Atmospheric observations: meteorological data from Antarctic and Arctic stations including temperature, pressure, humidity, wind, solar radiation, and ozone measurements",
+      "Ice and snow data: snow accumulation, ice thickness, glacier dynamics, and cryosphere change datasets from ground surveys and remote sensing",
+      "Marine environment monitoring: oceanographic data collected during expeditions including sea ice extent, salinity, current measurements, and marine biological surveys",
+      "Geological surveys: geological mapping, bedrock topography, and geophysical data from Antarctic ice sheet surveys",
+      "Ecology and biology datasets: records of Antarctic marine ecosystems, krill populations, penguin colonies, and microbial ecology studies",
+      "Expedition records: logistics and scientific records from over 40 Chinese Antarctic (CHINARE) and Arctic expeditions",
+      "Remote sensing imagery: satellite-derived data products for polar ice, snow cover, and surface change monitoring",
+      "Permafrost and geothermal data: subsurface temperature and permafrost thickness measurements from polar stations"
+    ],
+    "zh": [
+      "大气观测：南极和北极站点的气象数据，包括气温、气压、湿度、风速、太阳辐射和臭氧测量",
+      "冰雪数据：地面调查和遥感获取的积雪累积量、冰层厚度、冰川动力学和冰冻圈变化数据集",
+      "海洋环境监测：科考期间采集的海洋学数据，包括海冰范围、盐度、洋流测量和海洋生物调查",
+      "地质调查：南极冰盖地质制图、基岩地形和地球物理数据",
+      "生态与生物数据集：南极海洋生态系统、磷虾种群、企鹅种群和微生物生态学研究记录",
+      "科考记录：40余次中国南极（CHINARE）和北极科学考察的后勤和科研记录",
+      "遥感影像：用于极地冰雪、积雪覆盖和地表变化监测的卫星衍生数据产品",
+      "永久冻土和地热数据：极地站点的地下温度和多年冻土厚度测量数据"
+    ]
+  }
+}

--- a/firstdata/sources/china/technology/standards/china-openstd.json
+++ b/firstdata/sources/china/technology/standards/china-openstd.json
@@ -1,0 +1,79 @@
+{
+  "id": "china-openstd",
+  "name": {
+    "en": "China National Standards Full Text Public Access System",
+    "zh": "国家标准全文公开系统"
+  },
+  "description": {
+    "en": "The National Standards Full Text Public Access System (国家标准全文公开系统) is an official platform operated by the State Administration for Market Regulation (SAMR) that provides free public access to the full text of Chinese national standards (GB and GB/T standards). Launched to fulfill the mandate of China's Standardization Law, the system enables any user to read, search, and download the complete text of mandatory and recommended national standards covering industrial products, safety, environmental protection, health, infrastructure, and information technology. The platform houses over 40,000 active national standards and provides access to withdrawn and historical standards for reference. It is the authoritative open repository for China's national standardization system and is essential for enterprises, researchers, regulators, and trading partners seeking to comply with or analyze China's technical standards framework.",
+    "zh": "国家标准全文公开系统是由国家市场监督管理总局（市监总局）运营的官方平台，向社会免费提供中国国家标准（GB、GB/T标准）全文公开查询和下载服务。系统依据《标准化法》要求建设，任何用户均可检索和下载工业产品、安全、环境保护、卫生、基础设施和信息技术等领域强制性和推荐性国家标准全文。平台收录现行有效国家标准逾4万项，并提供废止和历史标准查询功能。该系统是中国国家标准体系的权威开放资源库，是企业合规、研究机构分析、监管机构参考及贸易伙伴了解中国技术标准体系的核心工具。"
+  },
+  "website": "https://openstd.samr.gov.cn/",
+  "data_url": "https://openstd.samr.gov.cn/",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "geographic_scope": "national",
+  "domains": [
+    "technology",
+    "industry",
+    "governance"
+  ],
+  "update_frequency": "irregular",
+  "tags": [
+    "国家标准全文公开系统",
+    "国家标准",
+    "national standards",
+    "GB标准",
+    "GB standards",
+    "GB/T",
+    "推荐性标准",
+    "recommended standards",
+    "强制性标准",
+    "mandatory standards",
+    "市场监督管理总局",
+    "SAMR",
+    "标准化",
+    "standardization",
+    "技术标准",
+    "technical standards",
+    "产品标准",
+    "product standards",
+    "安全标准",
+    "safety standards",
+    "环保标准",
+    "environmental standards",
+    "合规",
+    "compliance",
+    "贸易壁垒",
+    "trade barriers",
+    "标准查询",
+    "standards search",
+    "工业标准",
+    "industrial standards",
+    "信息技术标准",
+    "IT standards"
+  ],
+  "data_content": {
+    "en": [
+      "Mandatory national standards (GB): full text of compulsory standards that enterprises and products must comply with to be sold in China",
+      "Recommended national standards (GB/T): full text of voluntary technical standards covering industrial products, processes, and services",
+      "Standard metadata: standard number, title, applicable scope, issuing authority, effective date, and revision history",
+      "Historical standards: withdrawn and superseded standards for historical compliance reference and research",
+      "Standard classification: browsable by International Classification for Standards (ICS) and China Standard Classification (CCS) codes",
+      "Cross-reference data: relationships between national standards and corresponding international standards (ISO, IEC, ITU)",
+      "Sector-specific standards: standards for food safety, construction, automotive, electronics, chemicals, textiles, health, and environmental protection",
+      "Standards adoption data: tracking the adoption rate of international standards into China's national standards framework"
+    ],
+    "zh": [
+      "强制性国家标准（GB）：企业和产品在中国境内销售必须遵守的强制性标准全文",
+      "推荐性国家标准（GB/T）：涵盖工业产品、工艺流程和服务的自愿性技术标准全文",
+      "标准元数据：标准编号、标题、适用范围、发布机构、实施日期和修订历史",
+      "历史标准：已废止和被替代标准，供历史合规参考和研究使用",
+      "标准分类：按国际标准分类法（ICS）和中国标准分类法（CCS）浏览",
+      "交叉引用数据：国家标准与对应国际标准（ISO、IEC、ITU）的对照关系",
+      "行业专项标准：食品安全、建筑、汽车、电子、化工、纺织、卫生和环保等领域的标准",
+      "标准采标数据：追踪国际标准转化为中国国家标准的采标率"
+    ]
+  }
+}


### PR DESCRIPTION
## 新增5个中国权威数据源（下午批次）

### 数据源列表

| ID | 机构名称 | 网站 | 领域 |
|---|---|---|---|
| china-pkulaw | 北大法宝（北京大学法律数据库）| pkulaw.com | 法律/法规 |
| china-ggzy | 全国公共资源交易平台 | ggzy.gov.cn | 政务/经济 |
| china-miit-eidc | 工业和信息化部装备工业发展中心 | miit-eidc.org.cn | 工业/技术 |
| china-openstd | 国家标准全文公开系统 | openstd.samr.gov.cn | 标准/技术 |
| china-polar-service | 中国极地业务服务平台 | chinare.org.cn | 环境/科研 |

### 质量检查
- ✅ ID去重：所有ID均不在现有数据库中
- ✅ 网站域名去重：所有域名均不在现有数据库中（含开放PR）
- ✅ 黑名单检查：通过
- ✅ 网站URL验证：全部返回200/301/302
- ✅ data_url验证：均已核验（深链接404时使用根路径）
- ✅ 网站title核验：已确认机构名称匹配
- ✅ Schema验证：jsonschema验证通过
- ✅ 字段规范：authority_level、domains连字符、data_content数组等全部合规