### PR TITLE
feat: add 5 new data sources

### DIFF
--- a/firstdata/sources/china/infrastructure/china-cttic.json
+++ b/firstdata/sources/china/infrastructure/china-cttic.json
@@ -1,0 +1,58 @@
+{
+  "id": "china-cttic",
+  "name": {
+    "en": "China Transport Telecommunications & Information Center",
+    "zh": "中国交通通信信息中心"
+  },
+  "description": {
+    "en": "China Transport Telecommunications & Information Center (CTTIC) is the specialized public service institution under the Ministry of Transport of China, responsible for transport-sector telecommunications, informatization and satellite navigation services. It publishes integrated transportation statistics, road and waterway network data, logistics operation indicators, and supports national transport information systems including the BeiDou application in commercial vehicles and vessels.",
+    "zh": "中国交通通信信息中心（CTTIC）是中华人民共和国交通运输部直属的专业公共服务机构，承担交通行业通信、信息化与卫星导航服务，发布综合交通运输统计、公路和水路网络数据、物流运行指标等，并支持北斗在营运车辆和船舶中的应用等国家级交通信息系统。"
+  },
+  "website": "https://www.cttic.cn",
+  "data_url": "https://www.cttic.cn",
+  "api_url": null,
+  "authority_level": "government",
+  "country": "CN",
+  "domains": [
+    "transportation",
+    "infrastructure",
+    "logistics",
+    "technology"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "china",
+    "transport",
+    "telecommunications",
+    "informatization",
+    "logistics",
+    "beidou",
+    "satellite-navigation",
+    "commercial-vehicles",
+    "交通通信信息中心",
+    "交通运输部",
+    "北斗",
+    "营运车辆",
+    "交通信息化",
+    "CTTIC"
+  ],
+  "data_content": {
+    "en": [
+      "Integrated transport operation monitoring data",
+      "National road freight and passenger volume indicators",
+      "Waterway and coastal shipping statistics",
+      "BeiDou navigation applications in commercial fleets",
+      "Transport informatization standards and datasets",
+      "Industry think-tank reports on smart transportation"
+    ],
+    "zh": [
+      "综合交通运行监测数据",
+      "全国公路货运与客运运行指标",
+      "水路及沿海航运统计",
+      "营运车辆北斗导航应用数据",
+      "交通信息化标准与数据集",
+      "智慧交通行业智库报告"
+    ]
+  }
+}

--- a/firstdata/sources/china/infrastructure/china-ports-association.json
+++ b/firstdata/sources/china/infrastructure/china-ports-association.json
@@ -1,0 +1,61 @@
+{
+  "id": "china-ports-association",
+  "name": {
+    "en": "China Ports & Harbours Association",
+    "zh": "中国港口协会"
+  },
+  "description": {
+    "en": "The China Ports & Harbours Association (CPHA) is a national non-profit industry organization supervised by the Ministry of Transport of China. It brings together port enterprises, shipping terminals, logistics companies and research institutions, releasing official industry statistics including port cargo throughput, container throughput, shipping capacity utilization, port productivity indicators and industry development reports covering mainland Chinese ports.",
+    "zh": "中国港口协会（CPHA）是由中华人民共和国交通运输部主管的全国性港航业非营利社团组织，汇聚港口企业、码头运营商、航运物流公司及科研机构，发布包括港口货物吞吐量、集装箱吞吐量、船舶运力利用率、港口生产效率指标及行业发展报告等官方行业统计数据，覆盖中国大陆各港口。"
+  },
+  "website": "http://www.port.org.cn",
+  "data_url": "http://www.port.org.cn",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "domains": [
+    "transportation",
+    "infrastructure",
+    "trade",
+    "logistics"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "china",
+    "ports",
+    "harbours",
+    "shipping",
+    "port-throughput",
+    "container-throughput",
+    "cargo",
+    "logistics",
+    "中国港口协会",
+    "港口协会",
+    "港口吞吐量",
+    "集装箱吞吐量",
+    "港航业",
+    "水运",
+    "CPHA"
+  ],
+  "data_content": {
+    "en": [
+      "Monthly and annual port cargo throughput statistics",
+      "Container throughput (TEU) rankings by port",
+      "Shipping capacity and fleet utilization",
+      "Port productivity and operational efficiency indicators",
+      "Port infrastructure investment and construction data",
+      "Industry development reports and market analysis",
+      "Membership directory of Chinese ports and terminals"
+    ],
+    "zh": [
+      "月度及年度港口货物吞吐量统计",
+      "港口集装箱吞吐量（TEU）排名",
+      "船舶运力与船队利用率",
+      "港口生产效率与运营指标",
+      "港口基础设施投资与建设数据",
+      "行业发展报告与市场分析",
+      "全国港口与码头会员名录"
+    ]
+  }
+}

--- a/firstdata/sources/countries/europe/romania/romania-bvb.json
+++ b/firstdata/sources/countries/europe/romania/romania-bvb.json
@@ -1,0 +1,63 @@
+{
+  "id": "romania-bvb",
+  "name": {
+    "en": "Bucharest Stock Exchange",
+    "zh": "布加勒斯特证券交易所"
+  },
+  "description": {
+    "en": "Bucharest Stock Exchange (BVB) is Romania's principal securities exchange, regulated by the Romanian Financial Supervisory Authority (ASF). BVB operates equity, bond, and derivatives markets and disseminates official market data including share prices, indices (BET family), trading volumes, listed company filings, IPO and secondary-offering prospectuses, and corporate actions for Romanian listed companies.",
+    "zh": "布加勒斯特证券交易所（BVB）是罗马尼亚主要的证券交易所，受罗马尼亚金融监管局（ASF）监管。BVB运营股票、债券和衍生品市场，发布官方市场数据，包括股票价格、指数（BET系列）、交易量、上市公司披露、IPO及再融资招股书，以及罗马尼亚上市公司相关公司行为数据。"
+  },
+  "website": "https://www.bvb.ro",
+  "data_url": "https://www.bvb.ro/FinancialInstruments/Markets/Shares",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "RO",
+  "domains": [
+    "finance",
+    "securities",
+    "stock-market"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "daily",
+  "tags": [
+    "romania",
+    "bucharest",
+    "stock-exchange",
+    "BVB",
+    "securities",
+    "equities",
+    "bonds",
+    "derivatives",
+    "BET-index",
+    "IPO",
+    "market-data",
+    "罗马尼亚",
+    "布加勒斯特",
+    "证券交易所",
+    "股票市场",
+    "招股书"
+  ],
+  "data_content": {
+    "en": [
+      "Real-time and historical share prices",
+      "Market indices (BET, BET-TR, BET-XT, BET-BK)",
+      "Trading volumes and turnover statistics",
+      "Listed company disclosures and financial filings",
+      "IPO, SPO and bond issue prospectuses",
+      "Corporate actions (dividends, splits, mergers)",
+      "Derivatives and fixed-income market data",
+      "Market participant directory"
+    ],
+    "zh": [
+      "股票实时与历史价格",
+      "市场指数（BET、BET-TR、BET-XT、BET-BK）",
+      "交易量与成交金额统计",
+      "上市公司披露与财务报告",
+      "IPO、再融资与债券发行招股书",
+      "公司行为（股息、拆股、并购）",
+      "衍生品与固定收益市场数据",
+      "市场参与者名录"
+    ]
+  }
+}

--- a/firstdata/sources/countries/oceania/australia/asx.json
+++ b/firstdata/sources/countries/oceania/australia/asx.json
@@ -1,0 +1,63 @@
+{
+  "id": "asx",
+  "name": {
+    "en": "Australian Securities Exchange",
+    "zh": "澳大利亚证券交易所"
+  },
+  "description": {
+    "en": "The Australian Securities Exchange (ASX) is Australia's primary securities exchange and one of the leading financial markets in the Asia-Pacific region. ASX provides official market data covering listed equities, indices (S&P/ASX 200, All Ordinaries), exchange-traded funds, interest-rate and equity derivatives, IPO and secondary-listing filings, short-selling reports, and corporate governance disclosures for companies listed on ASX.",
+    "zh": "澳大利亚证券交易所（ASX）是澳大利亚主要的证券交易所，也是亚太地区领先的金融市场之一。ASX提供涵盖上市股票、指数（标普/ASX 200、全普指数）、交易所交易基金、利率及股票衍生品、IPO及二次上市披露文件、卖空报告以及上市公司治理披露在内的官方市场数据。"
+  },
+  "website": "https://www.asx.com.au",
+  "data_url": "https://www.asx.com.au/markets",
+  "api_url": null,
+  "authority_level": "market",
+  "country": "AU",
+  "domains": [
+    "finance",
+    "securities",
+    "stock-market",
+    "derivatives"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "daily",
+  "tags": [
+    "australia",
+    "asx",
+    "stock-exchange",
+    "securities",
+    "equities",
+    "ASX-200",
+    "All-Ordinaries",
+    "derivatives",
+    "ETF",
+    "IPO",
+    "market-data",
+    "澳大利亚",
+    "澳洲证券交易所",
+    "股票市场",
+    "澳交所"
+  ],
+  "data_content": {
+    "en": [
+      "Real-time and historical equity prices",
+      "Market indices (S&P/ASX 200, All Ordinaries, sector indices)",
+      "Listed company announcements and filings",
+      "IPO and secondary-listing prospectuses",
+      "Derivatives and interest-rate market data",
+      "ETF and managed funds data",
+      "Short-selling and securities lending reports",
+      "Market statistics and trading activity"
+    ],
+    "zh": [
+      "股票实时与历史价格",
+      "市场指数（标普/ASX 200、全普指数、行业指数）",
+      "上市公司公告与披露文件",
+      "IPO及二次上市招股书",
+      "衍生品与利率市场数据",
+      "ETF与基金数据",
+      "卖空与证券借贷报告",
+      "市场统计与交易活动数据"
+    ]
+  }
+}

--- a/firstdata/sources/regional/asean-centre-for-energy.json
+++ b/firstdata/sources/regional/asean-centre-for-energy.json
@@ -1,0 +1,60 @@
+{
+  "id": "asean-centre-for-energy",
+  "name": {
+    "en": "ASEAN Centre for Energy",
+    "zh": "东盟能源中心"
+  },
+  "description": {
+    "en": "The ASEAN Centre for Energy (ACE) is an intergovernmental organisation established by ASEAN member states to accelerate the integration of energy strategies across Southeast Asia. ACE publishes authoritative regional energy data covering energy supply and demand balances, electricity generation mix, renewable energy capacity, energy efficiency indicators, and the flagship ASEAN Energy Outlook which projects long-term energy pathways for the ten ASEAN countries.",
+    "zh": "东盟能源中心（ACE）是由东盟成员国共同设立的政府间组织，致力于推进东南亚地区能源战略一体化。ACE发布权威的区域能源数据，涵盖能源供需平衡、电力生产结构、可再生能源装机容量、能效指标，以及其旗舰出版物《东盟能源展望》——对东盟十国的中长期能源发展路径进行预测。"
+  },
+  "website": "https://aseanenergy.org",
+  "data_url": "https://aseanenergy.org/publications/",
+  "api_url": null,
+  "authority_level": "international",
+  "country": null,
+  "domains": [
+    "energy",
+    "environment",
+    "economics"
+  ],
+  "geographic_scope": "regional",
+  "update_frequency": "annual",
+  "tags": [
+    "asean",
+    "southeast-asia",
+    "energy",
+    "renewable-energy",
+    "electricity",
+    "energy-outlook",
+    "energy-efficiency",
+    "intergovernmental",
+    "ACE",
+    "东盟",
+    "东南亚",
+    "能源",
+    "可再生能源",
+    "能源展望",
+    "能源中心"
+  ],
+  "data_content": {
+    "en": [
+      "ASEAN Energy Outlook (long-term projections)",
+      "Regional energy balances (supply/demand)",
+      "Electricity generation mix and capacity",
+      "Renewable energy deployment statistics",
+      "Energy efficiency and conservation indicators",
+      "Cross-border power trade (ASEAN Power Grid)",
+      "Country-level energy profiles for 10 ASEAN members"
+    ],
+    "zh": [
+      "《东盟能源展望》长期预测报告",
+      "区域能源平衡（供需）数据",
+      "电力生产结构与装机容量",
+      "可再生能源部署统计",
+      "能效与节能指标",
+      "跨境电力贸易（东盟电网）",
+      "东盟十国国别能源数据"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Add 5 new authoritative data sources identified from user traces analysis.

### New Sources

| ID | Authority | Country/Region | Domains |
|---|---|---|---|
| `china-ports-association` | other (industry association under MOT) | CN | transportation, infrastructure, trade, logistics |
| `china-cttic` | government (MOT-affiliated) | CN | transportation, infrastructure, logistics, technology |
| `romania-bvb` | market | RO | finance, securities, stock-market |
| `asean-centre-for-energy` | international | regional (ASEAN) | energy, environment, economics |
| `asx` | market | AU | finance, securities, stock-market, derivatives |

### Coverage Highlights

- **China focus**: two new CN sources covering maritime ports (CPHA) and transport telecom/BeiDou (CTTIC)
- **Europe**: Romania's national stock exchange
- **Regional**: ASEAN Centre for Energy fills a gap for Southeast Asia energy data
- **Oceania**: Australian Securities Exchange

### Validation

- ✅ ID uniqueness verified against main + open PRs (/tmp/all-source-ids.txt, 622 entries)
- ✅ Website domain dedup verified against /tmp/all-source-websites.txt (577 entries)
- ✅ Blacklist check passed (check-blacklist.sh)
- ✅ Schema validation passed (datasource-schema.json)
- ✅ All data_url endpoints return HTTP 200
- ✅ `make check-ids` → All IDs unique
- ✅ Under 5-source PR limit