### PR TITLE
feat(schema): enforce no-whitespace in tags via pattern `^\\S+$`

### DIFF
--- a/firstdata/schemas/datasource-schema.json
+++ b/firstdata/schemas/datasource-schema.json
@@ -153,9 +153,10 @@
     },
     "tags": {
       "type": "array",
-      "description": "Search tags - mixed Chinese/English keywords, synonyms, data types, and related terms for improved discoverability",
+      "description": "Search tags - mixed Chinese/English keywords, synonyms, data types, and related terms for improved discoverability. Must not contain whitespace; use hyphens for multi-word English phrases (e.g., 'economic-growth' not 'economic growth'). Convention: preserve case of acronyms (GDP/IPO/NNSA etc.) in new entries.",
       "items": {
-        "type": "string"
+        "type": "string",
+        "pattern": "^\\S+$"
       },
       "minItems": 1,
       "examples": [


### PR DESCRIPTION
## Summary

Adds hard schema-level enforcement that tags must not contain whitespace.

```diff
"items": {
-  "type": "string"
+  "type": "string",
+  "pattern": "^\\\\S+$"
}
```

Also updates description to state the rule + acronym-case convention.

## Why

Tags containing spaces (e.g. `"economic growth"`) break tokenizer/index semantics. Schema description has always said "mixed Chinese/English keywords" and examples always used hyphens (`economic-growth`), but there was no enforcement. This PR closes the gap.

## Prereq

Merged PR #196 cleaned up 322 existing files (2967 space-tag violations → 0). Main is clean; this PR just locks the door behind us.

## Validation

Ran `make validate` against current main — all files pass.

## Three-way context

Ref: 2026-04-30 alignment (明鉴/墨子/明察). This is the 2nd of 2 back-to-back PRs.
1. PR #196 cleanup (merged) ✅
2. **This PR** (enforcement)

## Convention (documented in description)
- **Must**: no whitespace in tag strings
- **Should (new entries)**: preserve case of acronyms (GDP/IPO/NNSA/CBIRC/etc.)
- **Tolerated (historical)**: lowercase acronyms on main (from #196 scope creep, accepted)

## Checklist
- [x] `make validate` passes on main
- [x] Schema still allows mixed CN/EN
- [x] No source file changes
- [x] Description free of banned terms