### PR TITLE
feat: add 5 China authority sources (2026-04-30 下午批次)

### DIFF
--- a/firstdata/sources/china/governance/china-cfpa.json
+++ b/firstdata/sources/china/governance/china-cfpa.json
@@ -1,0 +1,55 @@
+{
+    "id": "china-cfpa",
+    "name": {
+        "en": "China Fire Protection Association",
+        "zh": "中国消防协会"
+    },
+    "description": {
+        "en": "The China Fire Protection Association (CFPA) is the national academic and industry organization for fire safety and emergency rescue, operating under the guidance of the Ministry of Emergency Management. CFPA publishes annual fire statistics reports covering the number of fire incidents, casualties, economic losses, fire causes, and building type breakdowns across China. It also produces technical standards, scientific research outputs, and fire prevention guidance. CFPA data is the authoritative source for national fire safety situation analysis and urban fire risk assessment.",
+        "zh": "中国消防协会（消防协会）是在应急管理部指导下开展消防科技与行业自律的全国性社团组织。协会发布年度火灾统计报告，涵盖全国火灾起数、伤亡人数、直接经济损失、起火原因及建筑类型分布等数据，同时出版技术标准、科研成果及消防宣传材料。消防协会数据是分析全国火灾安全形势和城市火灾风险的权威来源。"
+    },
+    "website": "http://www.cfpa.cn",
+    "data_url": "http://www.cfpa.cn",
+    "api_url": null,
+    "authority_level": "other",
+    "country": "CN",
+    "geographic_scope": "national",
+    "update_frequency": "annual",
+    "domains": [
+        "public-safety",
+        "emergency-management",
+        "statistics"
+    ],
+    "tags": [
+        "china",
+        "cfpa",
+        "消防协会",
+        "fire-protection",
+        "消防",
+        "fire-safety",
+        "消防安全",
+        "emergency-management",
+        "应急管理",
+        "fire-statistics",
+        "火灾统计",
+        "disaster",
+        "safety",
+        "annual-report"
+    ],
+    "data_content": {
+        "en": [
+            "Annual Fire Statistics - National fire incident count, casualties, economic losses, and fire cause analysis",
+            "Regional Fire Data - Provincial and city-level fire occurrence and loss breakdowns",
+            "Building Type Fire Analysis - Fire statistics segmented by residential, commercial, industrial, and public facility types",
+            "Fire Prevention Standards - Technical standards and guidelines for fire risk assessment and prevention",
+            "Research Publications - Academic papers and reports on fire science, suppression technology, and safety engineering"
+        ],
+        "zh": [
+            "年度火灾统计 - 全国火灾起数、伤亡人数、直接经济损失及起火原因分析",
+            "地区火灾数据 - 各省市火灾发生情况及损失分布",
+            "建筑类型火灾分析 - 按住宅、商业、工业及公共设施分类的火灾统计",
+            "消防技术标准 - 火灾风险评估与预防的技术规范和指引",
+            "科研出版物 - 消防科学、灭火技术及安全工程学术论文与报告"
+        ]
+    }
+}

--- a/firstdata/sources/china/governance/china-nncc.json
+++ b/firstdata/sources/china/governance/china-nncc.json
@@ -1,0 +1,56 @@
+{
+    "id": "china-nncc",
+    "name": {
+        "en": "China National Narcotics Control Commission",
+        "zh": "中国国家禁毒委员会"
+    },
+    "description": {
+        "en": "The China National Narcotics Control Commission (NNCC) is the top-level inter-ministerial body overseeing drug control policy and enforcement in China. Its official portal, China Anti-Drug Network (中国禁毒网), publishes authoritative national drug control reports, annual drug situation assessments, data on drug-related crimes, rehabilitation statistics, synthetic drug trend analyses, and public awareness campaign outcomes. NNCC data is the primary official source for understanding China's drug abuse epidemiology, enforcement actions, and policy progress.",
+        "zh": "中国国家禁毒委员会（禁毒委）是负责统筹协调全国禁毒工作的最高部际协调机构。其官方门户《中国禁毒网》发布权威的全国毒品形势报告、年度毒情综述、涉毒违法犯罪统计、戒毒康复数据、合成毒品趋势分析及禁毒宣传活动成效等信息，是了解中国禁毒执法、毒品滥用流行病学及政策进展的主要官方数据来源。"
+    },
+    "website": "http://www.nncc626.com",
+    "data_url": "http://www.nncc626.com",
+    "api_url": null,
+    "authority_level": "government",
+    "country": "CN",
+    "geographic_scope": "national",
+    "update_frequency": "annual",
+    "domains": [
+        "public-safety",
+        "governance",
+        "health",
+        "crime"
+    ],
+    "tags": [
+        "china",
+        "nncc",
+        "禁毒委",
+        "drug-control",
+        "禁毒",
+        "narcotics",
+        "毒品",
+        "anti-drug",
+        "drug-crime",
+        "涉毒犯罪",
+        "rehabilitation",
+        "戒毒",
+        "drug-situation",
+        "毒品形势"
+    ],
+    "data_content": {
+        "en": [
+            "Annual Drug Situation Reports - National drug abuse trends, seizure volumes, and enforcement statistics",
+            "Drug-Related Crime Data - Arrests, prosecutions, and conviction statistics for narcotics offenses",
+            "Rehabilitation Statistics - Data on compulsory drug detoxification and community-based recovery programs",
+            "Synthetic Drug Trends - Intelligence and statistical analyses on new psychoactive substances",
+            "Drug Control Policy Documents - Laws, regulations, and national action plans for drug prevention and control"
+        ],
+        "zh": [
+            "年度毒品形势报告 - 全国毒品滥用趋势、缴获数量及执法统计",
+            "涉毒违法犯罪数据 - 毒品犯罪的抓获、起诉及定罪统计",
+            "戒毒康复统计 - 强制隔离戒毒及社区康复计划数据",
+            "合成毒品趋势分析 - 新型精神活性物质情报及统计分析",
+            "禁毒政策文件 - 禁毒相关法律法规及国家行动计划"
+        ]
+    }
+}

--- a/firstdata/sources/china/governance/culture/china-cflac.json
+++ b/firstdata/sources/china/governance/culture/china-cflac.json
@@ -1,0 +1,55 @@
+{
+    "id": "china-cflac",
+    "name": {
+        "en": "China Federation of Literary and Art Circles",
+        "zh": "中国文学艺术界联合会"
+    },
+    "description": {
+        "en": "The China Federation of Literary and Art Circles (CFLAC) is the top-level national organization uniting Chinese artists, writers, filmmakers, musicians, and other creative professionals. Its official portal, China Art Net (中国文艺网), publishes statistics and reports on the development of China's cultural and creative industries, including performing arts attendance, film production data, literary output, fine arts exhibition records, and cultural infrastructure statistics. CFLAC provides the authoritative institutional perspective on trends in Chinese culture and the arts sector.",
+        "zh": "中国文学艺术界联合会（中国文联）是联合全国文艺界的最高全国性组织，涵盖作家、电影人、音乐家等各类文艺工作者。其官方门户《中国文艺网》发布中国文化创意产业发展统计报告，内容涵盖演艺观众人次、影视产量、文学创作成果、美术展览记录及文化基础设施数据。中国文联为了解中国文化与艺术行业趋势提供了权威的机构视角。"
+    },
+    "website": "https://www.cflac.org.cn",
+    "data_url": "https://www.cflac.org.cn",
+    "api_url": null,
+    "authority_level": "other",
+    "country": "CN",
+    "geographic_scope": "national",
+    "update_frequency": "irregular",
+    "domains": [
+        "culture",
+        "arts",
+        "media"
+    ],
+    "tags": [
+        "china",
+        "cflac",
+        "中国文联",
+        "arts-culture",
+        "文学艺术",
+        "performing-arts",
+        "表演艺术",
+        "literature",
+        "文学",
+        "film",
+        "电影",
+        "music",
+        "creative-industry",
+        "文化产业"
+    ],
+    "data_content": {
+        "en": [
+            "Cultural Industry Reports - Annual statistics on China's performing arts, visual arts, and literary output",
+            "Film and TV Production Data - Feature film production counts, box office reference data, and broadcasting statistics",
+            "Performing Arts Attendance - Audience numbers and venue statistics for theater, opera, dance, and music performances",
+            "Arts Exhibition Records - National and regional fine arts and photography exhibition statistics",
+            "Cultural Infrastructure Data - Statistics on cultural venues, art museums, libraries, and performance spaces"
+        ],
+        "zh": [
+            "文化产业报告 - 中国演艺、视觉艺术及文学创作年度统计",
+            "影视制作数据 - 故事片产量、票房参考数据及播出统计",
+            "演艺观众数据 - 戏剧、歌剧、舞蹈、音乐演出的观众人次及场馆统计",
+            "美术展览记录 - 全国及地方美术、摄影展览统计",
+            "文化基础设施数据 - 文化场馆、美术馆、图书馆及演出场所统计"
+        ]
+    }
+}

--- a/firstdata/sources/china/health/china-catcm.json
+++ b/firstdata/sources/china/health/china-catcm.json
@@ -1,0 +1,56 @@
+{
+    "id": "china-catcm",
+    "name": {
+        "en": "China Association of Traditional Chinese Medicine",
+        "zh": "中国中药协会"
+    },
+    "description": {
+        "en": "The China Association of Traditional Chinese Medicine (CATCM) is the national industry organization representing traditional Chinese medicine (TCM) enterprises, including herbal medicine producers, processors, and distributors. CATCM publishes authoritative market statistics on TCM herb production volumes, wholesale prices of medicinal materials, industry output value, trade data, and market trend analyses. It is the primary source for supply-and-demand data on Chinese herbal medicine markets and a key reference for TCM industry policy and standardization.",
+        "zh": "中国中药协会（中药协）是代表中药企业（含中药材生产、加工、流通企业）的全国性行业组织。协会发布权威的中药材产量、中药材市场批发价格、行业产值、进出口贸易数据及市场趋势分析，是了解中药材供需行情和中药产业政策、标准化工作的主要数据来源。"
+    },
+    "website": "https://www.catcm.org.cn",
+    "data_url": "https://www.catcm.org.cn",
+    "api_url": null,
+    "authority_level": "other",
+    "country": "CN",
+    "geographic_scope": "national",
+    "update_frequency": "monthly",
+    "domains": [
+        "health",
+        "pharmaceuticals",
+        "agriculture",
+        "trade"
+    ],
+    "tags": [
+        "china",
+        "catcm",
+        "中药协",
+        "traditional-chinese-medicine",
+        "中医药",
+        "herbal-medicine",
+        "中药材",
+        "tcm",
+        "medicinal-herbs",
+        "药材价格",
+        "herb-prices",
+        "中药产业",
+        "pharmaceuticals",
+        "market-data"
+    ],
+    "data_content": {
+        "en": [
+            "TCM Herb Market Prices - Wholesale price indices for hundreds of traditional Chinese medicinal herbs",
+            "Industry Output Statistics - Annual output value, production volumes, and enterprise data for TCM industry",
+            "Import/Export Trade Data - TCM herb and product trade statistics with major partner countries",
+            "Market Trend Reports - Periodic analyses of supply-demand dynamics in Chinese herbal medicine markets",
+            "Policy and Standardization Documents - Industry standards, quality specifications, and regulatory guidance for TCM materials"
+        ],
+        "zh": [
+            "中药材市场价格 - 数百种中药材批发价格指数",
+            "行业产值统计 - 中药行业年度产值、产量及企业数据",
+            "进出口贸易数据 - 中药材及中药产品与主要贸易伙伴的贸易统计",
+            "市场趋势报告 - 中药材市场供需动态的阶段性分析",
+            "政策与标准化文件 - 中药材行业标准、质量规范及监管指引"
+        ]
+    }
+}

--- a/firstdata/sources/china/industry/china-csei.json
+++ b/firstdata/sources/china/industry/china-csei.json
@@ -1,0 +1,57 @@
+{
+    "id": "china-csei",
+    "name": {
+        "en": "China Special Equipment Inspection and Research Institute",
+        "zh": "中国特种设备检测研究院"
+    },
+    "description": {
+        "en": "The China Special Equipment Inspection and Research Institute (CSEI) is a national-level research and technical service institution under the State Administration for Market Regulation (SAMR), focusing on safety inspection of special equipment including pressure vessels, pressure piping, boilers, elevators, cranes, passenger ropeways, and large amusement rides. CSEI publishes annual special equipment safety situation reports, accident statistics, safety supervision data, and technical standards. Its data is the authoritative source for special equipment safety risk assessment and industrial accident prevention in China.",
+        "zh": "中国特种设备检测研究院（中国特检院）是国家市场监督管理总局直属的国家级特种设备安全检测技术机构，专注于压力容器、压力管道、锅炉、电梯、起重机械、客运索道及大型游乐设施等特种设备的安全检测研究。研究院发布年度特种设备安全状况报告、事故统计、安全监察数据及技术标准，是中国特种设备安全风险评估和工业事故预防的权威数据来源。"
+    },
+    "website": "https://www.csei.org.cn",
+    "data_url": "https://www.csei.org.cn",
+    "api_url": null,
+    "authority_level": "research",
+    "country": "CN",
+    "geographic_scope": "national",
+    "update_frequency": "annual",
+    "domains": [
+        "safety",
+        "industrial-equipment",
+        "standards",
+        "governance"
+    ],
+    "tags": [
+        "china",
+        "csei",
+        "特检院",
+        "special-equipment",
+        "特种设备",
+        "safety-inspection",
+        "安全检测",
+        "pressure-vessel",
+        "压力容器",
+        "elevator",
+        "电梯",
+        "industrial-safety",
+        "工业安全",
+        "accident-statistics",
+        "事故统计"
+    ],
+    "data_content": {
+        "en": [
+            "Annual Special Equipment Safety Reports - National statistics on special equipment quantities, accidents, and safety supervision",
+            "Accident Statistics - Detailed breakdowns of accidents by equipment type, cause, severity, and region",
+            "Equipment Registration Data - Counts of registered special equipment by category and province",
+            "Safety Inspection Standards - Technical specifications and methods for special equipment safety assessment",
+            "Research Publications - Academic and technical reports on failure analysis, risk assessment, and safety engineering"
+        ],
+        "zh": [
+            "年度特种设备安全状况报告 - 全国特种设备数量、事故及安全监察统计",
+            "事故统计 - 按设备类型、事故原因、严重程度及地区分类的详细事故数据",
+            "设备登记数据 - 各类特种设备按类别和省份的登记数量",
+            "安全检测标准 - 特种设备安全评估的技术规范和检测方法",
+            "科研出版物 - 失效分析、风险评估及安全工程学术与技术报告"
+        ]
+    }
+}


### PR DESCRIPTION
## 新增5个中国权威数据源（下午批次）

### 新增数据源

| ID | 机构名称 | 领域 | 权威级别 |
|---|---|---|---|
| china-nncc | 中国国家禁毒委员会 | 公共安全/治理 | government |
| china-catcm | 中国中药协会 | 健康/中医药 | other |
| china-cfpa | 中国消防协会 | 公共安全/消防 | other |
| china-cflac | 中国文学艺术界联合会 | 文化/艺术 | other |
| china-csei | 中国特种设备检测研究院 | 安全/工业设备 | research |

### 检查清单
- [x] ID 去重（全量检查）
- [x] 网站域名去重
- [x] 黑名单检查通过
- [x] website URL 可访问（200/301/302）
- [x] data_url 非200时已改为根路径
- [x] 网站 title 与机构名称匹配
- [x] make check 验证通过（632个ID全部唯一）
- [x] JSON schema 合规（data_content数组、domains连字符、authority_level合法值）