### PR TITLE
feat: add 1 new data source (China CEMIA)

### DIFF
--- a/firstdata/sources/china/technology/industry_associations/china-cemia.json
+++ b/firstdata/sources/china/technology/industry_associations/china-cemia.json
@@ -1,0 +1,54 @@
+{
+  "id": "china-cemia",
+  "name": {
+    "en": "China Electronic Materials Industry Association",
+    "zh": "中国电子材料行业协会"
+  },
+  "description": {
+    "en": "China Electronic Materials Industry Association (CEMIA), founded in 1989 and supervised by MIIT, is the national industry association covering semiconductor materials, electronic-grade specialty gases, silicon wafers, third-generation semiconductor materials (SiC/GaN), and photovoltaic materials. Through dedicated sub-committees such as the Semiconductor Materials Branch, CEMIA publishes industry statistics, development reports, and standards for China's electronic materials sector.",
+    "zh": "中国电子材料行业协会（CEMIA）成立于1989年，是工信部主管的全国性行业协会，业务范围覆盖半导体材料、电子特种气体、硅片、第三代半导体材料（SiC/GaN）、光伏材料等领域，下设半导体材料分会等多个专业分会，发布中国电子材料行业的产业统计、发展报告与行业标准。"
+  },
+  "website": "http://www.cemia.org.cn",
+  "data_url": "http://www.cemia.org.cn",
+  "api_url": null,
+  "authority_level": "other",
+  "country": "CN",
+  "domains": [
+    "semiconductor-materials",
+    "electronic-materials",
+    "photovoltaic-materials",
+    "industry"
+  ],
+  "geographic_scope": "national",
+  "update_frequency": "monthly",
+  "tags": [
+    "半导体材料",
+    "第三代半导体",
+    "碳化硅",
+    "氮化镓",
+    "SiC",
+    "GaN",
+    "electronic-materials",
+    "电子特气",
+    "光伏材料",
+    "industry-association",
+    "MIIT",
+    "china"
+  ],
+  "data_content": {
+    "en": [
+      "Semiconductor materials industry statistics and reports",
+      "Third-generation semiconductor (SiC/GaN) development data",
+      "Electronic specialty gas market data",
+      "Silicon wafer and photovoltaic materials statistics",
+      "China electronic materials industry standards"
+    ],
+    "zh": [
+      "半导体材料产业统计与报告",
+      "第三代半导体（SiC/GaN）产业发展数据",
+      "电子特种气体市场数据",
+      "硅片及光伏材料产业统计",
+      "中国电子材料行业标准"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

Adds 1 new authoritative Chinese industry-association data source identified from MCP user-query analysis on 2026-05-01.

## New source

| ID | Name | Authority | Country |
|---|---|---|---|
| china-cemia | 中国电子材料行业协会 (China Electronic Materials Industry Association) | Industry association under MIIT | CN |

CEMIA (founded 1989) is the national MIIT-supervised industry association covering semiconductor materials, electronic specialty gases, third-generation semiconductor (SiC/GaN), and photovoltaic materials. Its Semiconductor Materials Branch publishes statistics and reports directly relevant to recent user queries about China's third-generation semiconductor and power device industry.

## Checks

- [x] ID unique (deduped against main + open PRs)
- [x] Website domain unique
- [x] Not on blacklist (check-blacklist.sh passed)
- [x] Schema validation (make check passed)
- [x] Domain consistency (make check passed)
- [x] All IDs unique (make check-ids passed; 648 total)
- [x] China-focused, government-endorsed (MIIT-supervised)
- [x] Not commercial-paid

## Filtered-out candidates from today's pipeline

- 中国汽车工业协会 → already in repo (china-auto-association)
- 中国光伏行业协会 → already in repo (china-cpia)
- 中国功率半导体产业技术创新战略联盟 → no findable official website
- Commercial paid services filtered out
