### PR TITLE
fix(ids): rename china-cinic→china-cnnic & china-cinic-net→china-cinic (#233)

### DIFF
--- a/firstdata/sources/china/economy/macro/china-cinic.json
+++ b/firstdata/sources/china/economy/macro/china-cinic.json
@@ -1,5 +1,5 @@
 {
-  "id": "china-cinic-net",
+  "id": "china-cinic",
   "name": {
     "en": "China Industry Economic Information Network (CINIC)",
     "zh": "中国产业经济信息网"
@@ -22,7 +22,7 @@
   "update_frequency": "daily",
   "tags": [
     "cinic",
-    "china-cinic-net",
+    "china-cinic",
     "中国产业经济信息网",
     "中宣部",
     "industrial-economy",

--- a/firstdata/sources/china/technology/internet/china-cnnic.json
+++ b/firstdata/sources/china/technology/internet/china-cnnic.json
@@ -1,5 +1,5 @@
 {
-  "id": "china-cinic",
+  "id": "china-cnnic",
   "name": {
     "en": "China Internet Network Information Center",
     "zh": "中国互联网络信息中心",


### PR DESCRIPTION
## Summary

按 老板 在 #github 5/13 15:01 GMT+8 指令，直接修复 Issue #233 ID 错位问题。

## 变更

- `firstdata/sources/china/technology/internet/cnnic.json` → `china-cnnic.json`
  - `id`: `china-cinic` → `china-cnnic`（机构是中国互联网络信息中心 CNNIC，原 ID 错位）
- `firstdata/sources/china/economy/macro/china-cinic-net.json` → `china-cinic.json`
  - `id`: `china-cinic-net` → `china-cinic`（CNNIC 让出名称后，真正的 CINIC = 中国产业经济信息网回归正名，去掉 PR #232 的防御性 `-net` 后缀）
- 同步更新文件内 tag `"china-cinic-net"` → `"china-cinic"`

## 一致性

| ID | 实际机构 | 缩写 | 域名 |
|---|---|---|---|
| `china-cnnic` | 中国互联网络信息中心 | CNNIC | cnnic.cn ✓ |
| `china-cinic` | 中国产业经济信息网 | CINIC | cinic.org.cn ✓ |

ID 与官方缩写、域名一致。

## 检查

- ✅ `bash scripts/pre-pr-check.sh` rc=0（保密 + `--tags-lint`）
- ✅ JSON 5/5 valid
- ✅ 两文件改动精准：仅 id + 文件名 + 一个内部 tag 引用，3 行改动
- ⚠️ Indexes 由 post-merge workflow 自动 regen（无需手改）

## 关联

Closes #233
